### PR TITLE
96 sprint 2 frontend update session config

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -32,7 +32,7 @@ class SessionForm(FlaskForm):
         validate_choice=False
     )
 
-    submit = SubmitField('Update')
+    submit = SubmitField('')
 
 #straight up copied from https://wtforms.readthedocs.io/en/3.0.x/specific_problems/?highlight=listwidget#specialty-field-tricks
 

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -43,6 +43,8 @@ def set_session_form_select_options(form):
     form.session_name.choices = session_name_choices
     form.session_time.choices = session_time_choices
 
+    form.submit.label.text = "Create"
+
 def set_updatesession_form_select_options(current_session, current_unit, form):
 
     unit_choices = [(current_unit.unitID, current_unit.unitCode)]
@@ -69,3 +71,5 @@ def set_updatesession_form_select_options(current_session, current_unit, form):
     form.unit.default = current_unit.unitID
     form.session_name.default = current_session.sessionName
     form.session_time.default = current_session.sessionTime
+
+    form.submit.label.text = "Update"

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -42,3 +42,30 @@ def set_session_form_select_options(form):
     form.unit.choices = unit_choices
     form.session_name.choices = session_name_choices
     form.session_time.choices = session_time_choices
+
+def set_updatesession_form_select_options(current_session, current_unit, form):
+
+    unit_choices = [(current_unit.unitID, current_unit.unitCode)]
+
+    session_name_choices = []
+    session_time_choices = []
+
+    # get session names for unit
+    session_names = current_unit.sessionNames.split('|')
+    for name in session_names :
+        session_name_choices.append(name)
+
+    # get session times for unit
+    session_times = current_unit.sessionTimes.split('|')
+    for time in session_times :
+        session_time_choices.append(time)
+    
+    # set form options
+    form.unit.choices = unit_choices
+    form.session_name.choices = session_name_choices
+    form.session_time.choices = session_time_choices
+
+    # set form defaults to current session
+    form.unit.default = current_unit.unitID
+    form.session_name.default = current_session.sessionName
+    form.session_time.default = current_session.sessionTime

--- a/app/routes.py
+++ b/app/routes.py
@@ -143,10 +143,20 @@ def updatesession():
     formatted_perth_time = perth_time.isoformat()
 
     if form.validate_on_submit():
-        # TODO: implement update session logic
-        print('Updating session details')
+        # Handle form submission
+        unit_id = form.unit.data
+        session_name = form.session_name.data
+        session_time = form.session_time.data
 
-    # set updatesession form select fields to match current
+        # Printing for debugging
+        print(f"Session Name: {session_name}")
+        print(f"Session Time: {session_time}")
+        print(f"Unit Id: {unit_id}")
+
+        # TODO: implement update session logic
+        print('Updating session details...')
+
+    # set updatesession form select fields to match current session's details
     current_session = existing_session[0]
     current_unit = GetUnit(unitID=current_session.unitID)[0]
     set_updatesession_form_select_options(current_session, current_unit, form)

--- a/app/routes.py
+++ b/app/routes.py
@@ -71,6 +71,12 @@ def home():
 @login_required
 def session():
 
+    # if session already exists, redirect to /updatesession
+    session_id = flask.session.get('session_id')
+    existing_session = GetSession(session_id)
+    if existing_session:
+        return redirect(url_for('updatesession'))
+
     form = SessionForm()
 
     # Get perth time
@@ -117,22 +123,33 @@ def session():
 
     # set session form select field options
     set_session_form_select_options(form)
+
     return flask.render_template('session.html', form=form, perth_time=formatted_perth_time)
 
 @app.route('/updatesession', methods=['GET', 'POST'])
 def updatesession():
-    
+
+    # if session doesn't exist, redirect to /session
+    session_id = flask.session.get('session_id')
+    existing_session = GetSession(session_id)
+    if not existing_session:
+        return redirect(url_for('session'))
+
     form = SessionForm()
 
-    # Get perth time
     perth_time = get_perth_time()
-    humanreadable_perth_time = perth_time.strftime('%B %d, %Y, %H:%M:%S %Z')
 
     # For JS formatting
     formatted_perth_time = perth_time.isoformat()
 
     if form.validate_on_submit():
+        # TODO: implement update session logic
         print('Updating session details')
+
+    # set updatesession form select fields to match current
+    current_session = existing_session[0]
+    current_unit = GetUnit(unitID=current_session.unitID)[0]
+    set_updatesession_form_select_options(current_session, current_unit, form)
 
     return flask.render_template('updatesession.html', form=form, perth_time=formatted_perth_time)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -64,12 +64,13 @@ def home():
 
     student_list.sort(key=lambda x: x['time'], reverse=True)
 
-    return flask.render_template('home.html', form=form, students=student_list, session=current_session, total_students=len(student_list), signed_in=signed_in_count, session_num=current_session.sessionID) 
+    return flask.render_template('home.html', form=form, students=student_list, current_session=current_session, total_students=len(student_list), signed_in=signed_in_count, session_num=current_session.sessionID) 
 	
 # CONFIGURATION - /session/ /admin/
 @app.route('/session', methods=['GET', 'POST'])
 @login_required
-def session():    
+def session():
+
     form = SessionForm()
 
     # Get perth time
@@ -114,16 +115,28 @@ def session():
         # Redirect back to home page with the session ID as a query parameter
         return flask.redirect(flask.url_for('home'))
 
-    
-    # print form errors
-    else :
-        print(form.errors)
-
     # set session form select field options
     set_session_form_select_options(form)
     return flask.render_template('session.html', form=form, perth_time=formatted_perth_time)
 
-#ADMIM - /unitconfig /
+@app.route('/updatesession', methods=['GET', 'POST'])
+def updatesession():
+    
+    form = SessionForm()
+
+    # Get perth time
+    perth_time = get_perth_time()
+    humanreadable_perth_time = perth_time.strftime('%B %d, %Y, %H:%M:%S %Z')
+
+    # For JS formatting
+    formatted_perth_time = perth_time.isoformat()
+
+    if form.validate_on_submit():
+        print('Updating session details')
+
+    return flask.render_template('updatesession.html', form=form, perth_time=formatted_perth_time)
+
+#ADMIN - /unitconfig /
 @app.route('/unitconfig', methods=['GET', 'POST'])
 @login_required
 def unitconfig():

--- a/app/routes.py
+++ b/app/routes.py
@@ -154,7 +154,6 @@ def updatesession():
         print(f"Unit Id: {unit_id}")
 
         # TODO: implement update session logic
-        print('Updating session details...')
 
     # set updatesession form select fields to match current session's details
     current_session = existing_session[0]

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -20,7 +20,7 @@ endwith %}
 <div class="container-fluid">
 	<div class="row mt-2 mx-md-5 mx-2">
 		<div class="d-flex justify-content-center align-items-center col-md-4 order-md-2">
-			<h4>{{ session.unitID }}-{{ session.sessionName }}-{{ session.sessionDate }}/{{ session.sessionTime }}</h4>
+			<h4>{{ current_session.unitID }}-{{ current_session.sessionName }}-{{ current_session.sessionDate }}/{{ current_session.sessionTime }}</h4>
 		</div>
 		
 		<div class="col-md-8 order-md-1">

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -21,9 +21,8 @@
 				<!-- Session Config: Visible to admins (1), coordinators (2), and facilitators (3) -->
 				
 				<a class="nav-link {% if request.path == url_for('session') %}active" aria-current="page{% endif %}"
-					href="{{ url_for('session') }}">Session Config</a>
+					href="{% if session['session_id']%}{{ url_for('updatesession')}}{% else %}{{ url_for('session') }}{% endif %}">Session Config</a>
 				
-
 				<!-- Unit Config: Only visible to admins (1) and coordinators (2) -->
 				{% if current_user.userType == 1 or current_user.userType == 2 %}
 					<a class="nav-link {% if request.path == url_for('unitconfig') %}active" aria-current="page{% endif %}"

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -29,6 +29,9 @@
     <div>
         <label for="current_time_display" class="form-label">Current Time:</label>
         <div id="current_time_display" data-perth-time="{{ perth_time }}">Loading...</div>
+
+        <!-- Hidden input to store current time for backend -->
+        <input type="hidden" id="current_time" name="current_time">
     </div>
 
     <!-- Buttons -->

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -3,19 +3,20 @@
 
 {% block content %}
 <h2>Session Configuration</h2>
+<p>You have no active sessions. Configure a new session below to view your class list.</p>
 <form method="POST" action="{{ url_for('session') }}">
     {{ form.hidden_tag() }}
 
     <!-- Unit Code -->
     <div class="mb-3">
         {{ form.unit.label(class="form-label") }}
-        {{ form.unit(class="form-select", onchange="updateDatabaseName()") }}
+        {{ form.unit(class="form-select") }}
     </div>
 
     <!-- Session Name -->
     <div class="mb-3">
         {{ form.session_name.label(class="form-label") }}
-        {{ form.session_name(class="form-select", onchange="updateDatabaseName()") }}
+        {{ form.session_name(class="form-select") }}
     </div>
 
     <!-- Session Time (e.g. "Morning") -->

--- a/app/templates/updatesession.html
+++ b/app/templates/updatesession.html
@@ -29,6 +29,9 @@
     <div>
         <label for="current_time_display" class="form-label">Current Time:</label>
         <div id="current_time_display" data-perth-time="{{ perth_time }}">Loading...</div>
+
+        <!-- Hidden input to store current time for backend -->
+        <input type="hidden" id="current_time" name="current_time">
     </div>
 
     <!-- Buttons -->
@@ -37,5 +40,4 @@
         <button type="button" class="btn btn-secondary" onclick="window.history.back()">Back</button>
     </div>
 </form>
-<script src="{{url_for('static', filename='js/session_config.js')}}"></script>
 {% endblock %}

--- a/app/templates/updatesession.html
+++ b/app/templates/updatesession.html
@@ -1,0 +1,42 @@
+<!-- File: templates/updatesession.html -->
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Session Configuration</h2>
+
+<p>You are already in an active session. To update these details:</p>
+<form method="POST" action="{{ url_for('updatesession') }}">
+    {{ form.hidden_tag() }}
+
+    <!-- Unit Code -->
+    <div class="mb-3">
+        {{ form.unit.label(class="form-label") }}
+        {{ form.unit(class="form-select", onchange="updateDatabaseName()") }}
+    </div>
+
+    <!-- Session Name -->
+    <div class="mb-3">
+        {{ form.session_name.label(class="form-label") }}
+        {{ form.session_name(class="form-select", onchange="updateDatabaseName()") }}
+    </div>
+
+    <!-- Session Time (e.g. "Morning") -->
+    <div class="mb-3">
+        {{ form.session_time.label(class="form-label") }}
+        {{ form.session_time(class="form-select") }}
+    </div>    
+
+    <!-- Current Time -->
+    <div>
+        <label for="current_time_display" class="form-label">Current Time:</label>
+        <div id="current_time_display" data-perth-time="{{ perth_time }}">Loading...</div>
+    </div>
+
+    <!-- Buttons -->
+    <div class="mt-3">
+        {{ form.submit(class="btn btn-primary") }}
+        <button type="button" class="btn btn-secondary" onclick="window.history.back()">Back</button>
+    </div>
+</form>
+<script src="{{url_for('static', filename='js/session_config.js')}}"></script>
+{% endblock %}

--- a/app/templates/updatesession.html
+++ b/app/templates/updatesession.html
@@ -3,21 +3,20 @@
 
 {% block content %}
 <h2>Session Configuration</h2>
-
-<p>You are already in an active session. To update these details:</p>
+<p>You are already in an active session. Update the session configuration below.</p>
 <form method="POST" action="{{ url_for('updatesession') }}">
     {{ form.hidden_tag() }}
 
     <!-- Unit Code -->
     <div class="mb-3">
         {{ form.unit.label(class="form-label") }}
-        {{ form.unit(class="form-select", onchange="updateDatabaseName()") }}
+        {{ form.unit(class="form-select") }}
     </div>
 
     <!-- Session Name -->
     <div class="mb-3">
         {{ form.session_name.label(class="form-label") }}
-        {{ form.session_name(class="form-select", onchange="updateDatabaseName()") }}
+        {{ form.session_name(class="form-select") }}
     </div>
 
     <!-- Session Time (e.g. "Morning") -->


### PR DESCRIPTION
In this PR:
If there is no current session, the session config is just the usual config new session.
If there is a current session already configured, session config takes you to a different route to allow you to update the current session configuration.
The update session config form has the current session's values as the defaults.

I've made it so that the unit for the session cannot be reconfigured (in the update session config form, the only option is the current unit), because if students (specific to a unit) are already signed in then changing the unit would mean the student attendance records would all be wrong. We can potentially change stuff in the future where if no students are signed in yet then they can or something like that - something to discuss later.

To test this you will want to delete your browsing data (i.e. delete the cookies).

This PR does not implement any of the backend of update session config (just the new session details are printed), as the limits of updating an existing session will probably depend on how we do the temp db (again something to discuss later and do for sprint 3).