### PR TITLE
Frontend overhaul pr 1,2 - login & css, home page & navbar

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -83,7 +83,7 @@ class AddUnitForm(FlaskForm):
 	enddate = DateField('End Date', validators=[DataRequired()])
 	#Need to add custom validators to check if files uploaded end in csv
 	sessionnames = StringField('Session Names:', validators=[DataRequired()], render_kw={"placeholder":"separate with |"})
-	facilitatorfile = FileField('Facilitator IDs', validators=[FileRequired(), FileAllowed(['csv'], "Only accepts .csv files")])
+	facilitatorfile = FileField('Facilitator List CSV upload', validators=[FileRequired(), FileAllowed(['csv'], "Only accepts .csv files")])
 	studentfile = FileField('Student List CSV Upload:', validators=[FileRequired(), FileAllowed(['csv'], "Only accepts .csv files")])
 	consentcheck = BooleanField('Photo Consent Required?')
 	sessionoccurence = MultiCheckboxField(
@@ -109,4 +109,4 @@ class AttendanceChangesForm(FlaskForm):
     login = BooleanField('Login')
     consent = BooleanField('Photo Consent')
     grade = StringField('Grade')
-    comments = TextAreaField('Comment')
+    comments = TextAreaField('Leave/edit comments')

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -1,0 +1,12 @@
+
+$(window).on("load resize", function () {
+	usedHeight = 0;
+	rect = $("#classTable")[0].getBoundingClientRect();
+	console.log(rect.top)
+	usedHeight += rect.top;
+	usedHeight += $(".home-footer").height();
+	//Arbitrary small amount of pixels for wiggle room at bottom
+	remainingHeight = window.innerHeight - usedHeight - 10
+	console.log("total" + window.innerHeight + "used" + usedHeight + "remaining" + remainingHeight)
+	$("#classTable").height(remainingHeight + "px")
+})

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -32,3 +32,25 @@ if (window.location.href.indexOf("session") != -1) {
     updateTime();
 
 }
+
+
+$(window).on("load resize", function () {
+    //!HARD CODED URL
+    if (top.location.pathname === '/home') {
+        usedHeight = 0;
+        if ($('#flashMessages').length > 0) {
+            usedHeight += $("flashMessages").height();
+        }
+        usedHeight += $("nav").height();
+        console.log($("nav").height());
+        usedHeight += $(".input-holder").height();
+        console.log($(".input-holder").height());
+        usedHeight += $(".home-footer").height();
+        console.log($(".home-footer").height())
+        remainingHeight = window.innerHeight - usedHeight - 40
+        console.log("total" + window.innerHeight + "used" + usedHeight + "remaining" + remainingHeight)
+        $("#classTable").height(remainingHeight + "px")
+
+    }
+
+})

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -38,16 +38,12 @@ $(window).on("load resize", function () {
     //!HARD CODED URL
     if (top.location.pathname === '/home') {
         usedHeight = 0;
-        if ($('#flashMessages').length > 0) {
-            usedHeight += $("flashMessages").height();
-        }
-        usedHeight += $("nav").height();
-        console.log($("nav").height());
-        usedHeight += $(".input-holder").height();
-        console.log($(".input-holder").height());
+        rect = $("#classTable")[0].getBoundingClientRect();
+        console.log(rect.top)
+        usedHeight += rect.top;
         usedHeight += $(".home-footer").height();
-        console.log($(".home-footer").height())
-        remainingHeight = window.innerHeight - usedHeight - 40
+
+        remainingHeight = window.innerHeight - usedHeight
         console.log("total" + window.innerHeight + "used" + usedHeight + "remaining" + remainingHeight)
         $("#classTable").height(remainingHeight + "px")
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -33,20 +33,8 @@ if (window.location.href.indexOf("session") != -1) {
 
 }
 
-
-$(window).on("load resize", function () {
-    //!HARD CODED URL
-    if (top.location.pathname === '/home') {
-        usedHeight = 0;
-        rect = $("#classTable")[0].getBoundingClientRect();
-        console.log(rect.top)
-        usedHeight += rect.top;
-        usedHeight += $(".home-footer").height();
-
-        remainingHeight = window.innerHeight - usedHeight
-        console.log("total" + window.innerHeight + "used" + usedHeight + "remaining" + remainingHeight)
-        $("#classTable").height(remainingHeight + "px")
-
-    }
-
-})
+//Works only on reload, but I doubt a user will be changing colour schemes and not expecting to have to reload
+if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    $(".modal").attr("data-bs-theme", "dark")
+    $(".navbar").attr("data-bs-theme", "dark")
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -42,4 +42,4 @@ if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').match
 //Closes an alert 3 seconds after it pops up
 setTimeout(function () {
     $('.alert').alert('close');
-}, 4000); 
+}, 3000); 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -38,3 +38,8 @@ if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').match
     $(".modal").attr("data-bs-theme", "dark")
     $(".navbar").attr("data-bs-theme", "dark")
 }
+
+//Closes an alert 3 seconds after it pops up
+setTimeout(function () {
+    $('.alert').alert('close');
+}, 4000); 

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -15,7 +15,7 @@
     --secondary: var(--bs-secondary);
     --danger: var(--bs-danger);
     --success: var(--bs-teal);
-    --bg: var(--bs-body-color);
+    --bg: var(--bs-gray-900);
     --text: var(--bs-gray-300);
   }
 }

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -42,6 +42,11 @@ body {
 }
 
 /* Table elements */
+#classTable {
+  overflow-y: scroll;
+  height: 0px;
+}
+
 .table-heading {
   background-color: color-mix(in srgb, var(--bg) 75%, var(--text) 25%);
   border-radius: 0.5rem;

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -96,6 +96,7 @@ body {
   --bs-modal-border-color: var(--text);
 }
 
+//Buttons
 .btn-primary {
   --bs-btn-color: var(--bs-white);
   --bs-btn-bg: var(--primary);
@@ -104,6 +105,16 @@ body {
   --bs-btn-hover-border-color: color-mix(in srgb, var(--primary), black 20%);
   --bs-btn-active-bg: color-mix(in srgb, var(--primary), black 25%);
   --bs-btn-active-border-color: color-mix(in srgb, var(--primary), black 25%);
+}
+
+.btn-secondary {
+  --bs-btn-color: var(--bs-white);
+  --bs-btn-bg: var(--secondary);
+  --bs-btn-border-color: var(--secondary);
+  --bs-btn-hover-bg: color-mix(in srgb, var(--secondary), black 20%);
+  --bs-btn-hover-border-color: color-mix(in srgb, var(--secondary), black 20%);
+  --bs-btn-active-bg: color-mix(in srgb, var(--secondary), black 25%);
+  --bs-btn-active-border-color: color-mix(in srgb, var(--secondary), black 25%);
 }
 
 .btn-success {

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -14,7 +14,7 @@
     --primary: var(--bs-primary);
     --secondary: var(--bs-secondary);
     --danger: var(--bs-danger);
-    --success: var(--bs-success);
+    --success: var(--bs-teal);
     --bg: var(--bs-body-color);
     --text: var(--bs-gray-300);
   }
@@ -59,11 +59,21 @@ body {
   background-color: var(--primary);
 }
 
-/* Darker grey for odd and even items for the student-suggestions on homepage */
-.list-group-item:nth-child(odd) {
-  background-color: #f8f9fa; /* Light grey for odd items */
+/* Form control changes */
+.form-control:focus {
+  /* https://stackoverflow.com/a/76910228 */
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--primary) 25%, transparent);
+  border-color: var(--primary);
 }
 
-.list-group-item:nth-child(even) {
-  background-color: #e9ecef; /* Slightly darker grey for even items */
+/* Bootstrap class css changes (all elements have this from version 5.2) */
+
+.btn-success {
+  --bs-btn-color: var(--bs-white);
+  --bs-btn-bg: var(--success);
+  --bs-btn-border-color: var(--success);
+  --bs-btn-hover-bg: color-mix(in srgb, var(--success), black 20%);
+  --bs-btn-hover-border-color: color-mix(in srgb, var(--success), black 20%);
+  --bs-btn-active-bg: color-mix(in srgb, var(--success), black 25%);
+  --bs-btn-active-border-color: color-mix(in srgb, var(--success), black 25%);
 }

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -1,3 +1,39 @@
+/* Variables */
+:root {
+  --primary: var(--bs-primary);
+  --secondary: var(--bs-secondary);
+  --danger: var(--bs-danger);
+  --success: var(--bs-success);
+  --bg: var(--bs-body-bg);
+  --text: var(--bs-body-color);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: var(--bs-primary);
+    --secondary: var(--bs-secondary);
+    --danger: var(--bs-danger);
+    --success: var(--bs-success);
+    --bg: var(--bs-body-color);
+    --text: var(--bs-gray-300);
+  }
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+/* Login page elements */
+.login-bg {
+  background-color: color-mix(in srgb, var(--bg) 90%, var(--text) 10%);
+}
+
+.login-box {
+  background-color: var(--bg);
+}
+
 /* Invalid input for configuration fields */
 .input-error {
   border: 2px solid red;
@@ -14,22 +50,20 @@
   }
 }
 
-
 .table-element {
   cursor: pointer;
   transition: background-color 0.3s ease-in-out;
 }
 
-
 .table-element:hover {
-  background-color: var(--bs-primary);
+  background-color: var(--primary);
 }
 
 /* Darker grey for odd and even items for the student-suggestions on homepage */
 .list-group-item:nth-child(odd) {
-    background-color: #f8f9fa; /* Light grey for odd items */
+  background-color: #f8f9fa; /* Light grey for odd items */
 }
 
 .list-group-item:nth-child(even) {
-    background-color: #e9ecef; /* Slightly darker grey for even items */
+  background-color: #e9ecef; /* Slightly darker grey for even items */
 }

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -72,6 +72,8 @@ body {
   background-color: var(--bg);
 }
 
+/* Bootstrap class css changes (all elements have this from version 5.2) */
+
 /* Form control changes */
 .form-control:focus {
   /* https://stackoverflow.com/a/76910228 */
@@ -79,7 +81,21 @@ body {
   border-color: var(--primary);
 }
 
-/* Bootstrap class css changes (all elements have this from version 5.2) */
+.navbar {
+  background-color: color-mix(in srgb, var(--bg) 75%, var(--text) 25%);
+  --bs-navbar-toggler-border-color: none;
+  --bs-navbar-toggler-focus-width: 1px;
+  --bs-navbar-hover-color: color-mix(in srgb, var(--text) 75%, transparent);
+  --bs-navbar-color: var(--text);
+  --bs-navbar-brand-color: var(--text);
+}
+
+.modal {
+  --bs-modal-color: var(--text);
+  --bs-modal-bg: var(--bg);
+  --bs-modal-border-color: var(--text);
+}
+
 .btn-primary {
   --bs-btn-color: var(--bs-white);
   --bs-btn-bg: var(--primary);

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -25,15 +25,6 @@ body {
   color: var(--text);
 }
 
-/* Login page elements */
-.login-bg {
-  background-color: color-mix(in srgb, var(--bg) 90%, var(--text) 10%);
-}
-
-.login-box {
-  background-color: var(--bg);
-}
-
 /* Invalid input for configuration fields */
 .input-error {
   border: 2px solid red;
@@ -50,13 +41,30 @@ body {
   }
 }
 
+/* Table elements */
+.table-heading {
+  background-color: color-mix(in srgb, var(--bg) 75%, var(--text) 25%);
+  border-radius: 0.5rem;
+}
+
 .table-element {
+  background-color: color-mix(in srgb, var(--bg) 90%, var(--text) 10%);
+  border-radius: 0.5rem;
   cursor: pointer;
   transition: background-color 0.3s ease-in-out;
 }
 
 .table-element:hover {
-  background-color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 60%, transparent);
+}
+
+/* Login page elements */
+.login-bg {
+  background-color: color-mix(in srgb, var(--bg) 90%, var(--text) 10%);
+}
+
+.login-box {
+  background-color: var(--bg);
 }
 
 /* Form control changes */
@@ -67,6 +75,15 @@ body {
 }
 
 /* Bootstrap class css changes (all elements have this from version 5.2) */
+.btn-primary {
+  --bs-btn-color: var(--bs-white);
+  --bs-btn-bg: var(--primary);
+  --bs-btn-border-color: var(--primary);
+  --bs-btn-hover-bg: color-mix(in srgb, var(--primary), black 20%);
+  --bs-btn-hover-border-color: color-mix(in srgb, var(--primary), black 20%);
+  --bs-btn-active-bg: color-mix(in srgb, var(--primary), black 25%);
+  --bs-btn-active-border-color: color-mix(in srgb, var(--primary), black 25%);
+}
 
 .btn-success {
   --bs-btn-color: var(--bs-white);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,9 @@
 </head>
 
 <body>
+	{% if request.path != url_for('login')%}
 	{% include 'navbar.html' %}
+	{% endif %}
 	{% block content %} {% endblock %}
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -3,7 +3,7 @@
 
 <!-- Flash Messages -->
 {% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %} 
+{% if messages %}
 {% for category, message in messages %} {%if category == 'error'%}
 <div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
 	{{ message }}
@@ -20,20 +20,21 @@ endwith %}
 <div class="container-fluid">
 	<div class="row mt-2 mx-md-5 mx-2">
 		<div class="d-flex justify-content-center align-items-center col-md-4 order-md-2">
-			<h4>{{ current_session.unitID }}-{{ current_session.sessionName }}-{{ current_session.sessionDate }}/{{ current_session.sessionTime }}</h4>
+			<h4>{{ current_session.unitID }}-{{ current_session.sessionName }}-{{ current_session.sessionDate }}/{{
+				current_session.sessionTime }}</h4>
 		</div>
-		
+
+		<!-- Input element -->
 		<div class="col-md-8 order-md-1">
 			<h2>
 				{{ signed_in }} signed in of {{ total_students }}
 			</h2>
-			<!-- Use Flask forms?-->
 			<form id="attendanceForm" method="POST" action="{{ url_for('add_student') }}">
 				{{ form.hidden_tag() }}
 				<div class="input-group">
-					<label for="studentSignIn" class="form-label visually-hidden">{{ form.student_sign_in.label }}</label>
+					{{ form.student_sign_in(id='student_search', placeholder="Enter name or ID...",
+					class="form-control") }}
 					{{ form.studentID(id='studentID') }}
-					{{ form.student_sign_in(id='student_search', class="form-control", placeholder="Enter name or ID...") }}
 					{{ form.consent_status(id="consentStatus", type="hidden") }}
 					<input type="hidden" id="hidden_consent_indicator" value="no">
 					<button id="student_sign_in_button" type="submit" class="btn btn-primary">Submit</button>
@@ -55,7 +56,8 @@ endwith %}
 			<span class="col">Photo</span>
 		</div>
 		{% for student in students%} <!-- onlick re-route to student page for this specific student -->
-		<div class="row table-element text-center my-2 py-2 rounded border border-primary" onclick="redirectToStudent('{{ student.id }}')">
+		<div class="row table-element text-center my-2 py-2 rounded border border-primary"
+			onclick="redirectToStudent('{{ student.id }}')">
 			<form id="studentForm_{{ student.id }}" action="/student" method="POST" style="display:none;">
 				<input type="hidden" name="student_id" value="{{ student.id }}">
 			</form>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -75,7 +75,7 @@
 		</div>
 	</div>
 	{% include 'signOut.html'%}
-	<div class="fixed-bottom d-flex justify-content-center home-footer mb-1">
+	<div class="fixed-bottom d-flex justify-content-center home-footer mb-2">
 		<button id="signOutButton" class="btn btn-danger w-50">Sign All Out</button>
 	</div>
 </div>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -77,7 +77,7 @@
 		</div>
 	</div>
 	{% include 'signOut.html'%}
-	<div class="row bg-body home-footer">
+	<div class="fixed-bottom row bg-body home-footer">
 		<button class="btn col-md-3 col">Sync</button>
 		<button id="signOutButton" class="btn btn-danger col">Sign All Out</button>
 		<button class="btn col-md-3 col">Download</button>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -5,20 +5,18 @@
 
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
-<div id="flashMessages">
-	{% for category, message in messages %}
-	{%if category == 'error'%}
-	<div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
-		{{ message }}
-		<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
-	</div>
-	{% else %}
-	<div class="alert alert-success alert-dismissable fade show d-flex justify-content-between" role="alert">
-		{{ message }}
-		<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
-	</div>
-	{% endif %}
+{% for category, message in messages %}
+{%if category == 'error'%}
+<div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
+	{{ message }}
+	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>
+{% else %}
+<div class="alert alert-success alert-dismissable fade show d-flex justify-content-between" role="alert">
+	{{ message }}
+	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{% endif %}
 {% endfor %} {% endif %} {% endwith %}
 
 <div class="container-fluid">

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -22,7 +22,7 @@
 {% endfor %} {% endif %} {% endwith %}
 
 <div class="container-fluid">
-	<div class="row mt-2 mx-md-5 mx-2 input-holder">
+	<div class="row mt-2 mx-md-5 mx-2">
 		<div class="d-flex justify-content-center align-items-center col-md-4 order-md-2">
 			<h4>{{ current_session.unitID }}-{{ current_session.sessionName }}-{{ current_session.sessionDate }}/{{
 				current_session.sessionTime }}</h4>
@@ -77,14 +77,13 @@
 		</div>
 	</div>
 	{% include 'signOut.html'%}
-	<div class="fixed-bottom row bg-body home-footer">
-		<button class="btn col-md-3 col">Sync</button>
-		<button id="signOutButton" class="btn btn-danger col">Sign All Out</button>
-		<button class="btn col-md-3 col">Download</button>
+	<div class="fixed-bottom d-flex justify-content-center home-footer mb-1">
+		<button id="signOutButton" class="btn btn-danger w-50">Sign All Out</button>
 	</div>
 </div>
 
-<script src="{{url_for('static', filename='js/consent.js')}}"></script>
+<script src="{{ url_for('static', filename='js/home.js') }}"></script>
+<script src="{{ url_for('static', filename='js/consent.js') }}"></script>
 <script src="{{ url_for('static', filename='js/student_suggestions.js') }}"></script>
 <script src="{{ url_for('static', filename='js/sign_out.js') }}"></script>
 {% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -2,23 +2,27 @@
 {% block content %}
 
 <!-- Flash Messages -->
+
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
-{% for category, message in messages %} {%if category == 'error'%}
-<div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
-	{{ message }}
-	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+<div id="flashMessages">
+	{% for category, message in messages %}
+	{%if category == 'error'%}
+	<div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
+		{{ message }}
+		<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+	</div>
+	{% else %}
+	<div class="alert alert-success alert-dismissable fade show d-flex justify-content-between" role="alert">
+		{{ message }}
+		<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+	</div>
+	{% endif %}
 </div>
-{% else %}
-<div class="alert alert-success alert-dismissable fade show d-flex justify-content-between" role="alert">
-	{{ message }}
-	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
-</div>
-{% endif %} {% endfor %} {% endif %} {%
-endwith %}
+{% endfor %} {% endif %} {% endwith %}
 
 <div class="container-fluid">
-	<div class="row mt-2 mx-md-5 mx-2">
+	<div class="row mt-2 mx-md-5 mx-2 input-holder">
 		<div class="d-flex justify-content-center align-items-center col-md-4 order-md-2">
 			<h4>{{ current_session.unitID }}-{{ current_session.sessionName }}-{{ current_session.sessionDate }}/{{
 				current_session.sessionTime }}</h4>
@@ -46,32 +50,34 @@ endwith %}
 
 	{% include 'photoConsent.html'%}
 	<!-- Table element -->
-	<div class="mx-4 mt-3 mx-md-5" id="classTable">
-		{% if total_students > 0 %}
-		<div class="row d-none d-md-flex text-center lead table-heading">
-			<span class="col">Name</span>
-			<span class="col">ID</span>
-			<span class="col">Login</span>
-			<span class="col">Photo</span>
-		</div>
-		<!-- https://getbootstrap.com/docs/5.3/components/scrollspy/ probably what we want -->
+	<div class="d-flex justify-content-center">
+		<div class="mx-4 mt-3 mx-md-5 container" id="classTable">
+			{% if total_students > 0 %}
+			<div class="row d-none d-md-flex text-center lead table-heading">
+				<span class="col">Name</span>
+				<span class="col">ID</span>
+				<span class="col">Login</span>
+				<span class="col">Photo</span>
+			</div>
+			<!-- https://getbootstrap.com/docs/5.3/components/scrollspy/ probably what we want -->
 
-		{% for student in students%} <!-- onlick re-route to student page for this specific
+			{% for student in students%} <!-- onlick re-route to student page for this specific
 			student -->
-		<div class="row table-element text-center my-2 py-2" onclick="redirectToStudent('{{ student.id }}')">
-			<form id="studentForm_{{ student.id }}" action="/student" method="POST" style="display:none;">
-				<input type="hidden" name="student_id" value="{{ student.id }}">
-			</form>
-			<span class="col-md col-6">{{student.name}}</span>
-			<span class="col-md col-6">{{student.number}}</span>
-			<span class="d-none d-md-inline col-md">{{student.login}}</span>
-			<span class="d-none d-md-inline col-md">{{student.photo}}</span>
+			<div class="row table-element text-center my-2 py-2" onclick="redirectToStudent('{{ student.id }}')">
+				<form id="studentForm_{{ student.id }}" action="/student" method="POST" style="display:none;">
+					<input type="hidden" name="student_id" value="{{ student.id }}">
+				</form>
+				<span class="col-md col-6">{{student.name}}</span>
+				<span class="col-md col-6">{{student.number}}</span>
+				<span class="d-none d-md-inline col-md">{{student.login}}</span>
+				<span class="d-none d-md-inline col-md">{{student.photo}}</span>
+			</div>
+			{% endfor %}
+			{% endif %}
 		</div>
-		{% endfor %}
-		{% endif %}
 	</div>
 	{% include 'signOut.html'%}
-	<div class="fixed-bottom row bg-body">
+	<div class="row bg-body home-footer">
 		<button class="btn col-md-3 col">Sync</button>
 		<button id="signOutButton" class="btn btn-danger col">Sign All Out</button>
 		<button class="btn col-md-3 col">Download</button>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -33,7 +33,7 @@ endwith %}
 				{{ form.hidden_tag() }}
 				<div class="input-group">
 					{{ form.student_sign_in(id='student_search', placeholder="Enter name or ID...",
-					class="form-control") }}
+					class="form-control", autocomplete="off") }}
 					{{ form.studentID(id='studentID') }}
 					{{ form.consent_status(id="consentStatus", type="hidden") }}
 					<input type="hidden" id="hidden_consent_indicator" value="no">
@@ -41,23 +41,24 @@ endwith %}
 				</div>
 				<div id="suggestions_container" class="list-group mt-2"></div>
 			</form>
-			{% include 'photoConsent.html'%}
 		</div>
-
 	</div>
 
+	{% include 'photoConsent.html'%}
 	<!-- Table element -->
 	<div class="mx-4 mt-3 mx-md-5" id="classTable">
 		{% if total_students > 0 %}
-		<div class="row d-none d-md-flex text-center lead bg-dark-subtle rounded">
+		<div class="row d-none d-md-flex text-center lead table-heading">
 			<span class="col">Name</span>
 			<span class="col">ID</span>
 			<span class="col">Login</span>
 			<span class="col">Photo</span>
 		</div>
-		{% for student in students%} <!-- onlick re-route to student page for this specific student -->
-		<div class="row table-element text-center my-2 py-2 rounded border border-primary"
-			onclick="redirectToStudent('{{ student.id }}')">
+		<!-- https://getbootstrap.com/docs/5.3/components/scrollspy/ probably what we want -->
+
+		{% for student in students%} <!-- onlick re-route to student page for this specific
+			student -->
+		<div class="row table-element text-center my-2 py-2" onclick="redirectToStudent('{{ student.id }}')">
 			<form id="studentForm_{{ student.id }}" action="/student" method="POST" style="display:none;">
 				<input type="hidden" name="student_id" value="{{ student.id }}">
 			</form>
@@ -69,13 +70,12 @@ endwith %}
 		{% endfor %}
 		{% endif %}
 	</div>
-
-	<div class="fixed-bottom row pb-2 bg-body">
+	{% include 'signOut.html'%}
+	<div class="fixed-bottom row bg-body">
 		<button class="btn col-md-3 col">Sync</button>
 		<button id="signOutButton" class="btn btn-danger col">Sign All Out</button>
 		<button class="btn col-md-3 col">Download</button>
 	</div>
-	{% include 'signOut.html'%}
 </div>
 
 <script src="{{url_for('static', filename='js/consent.js')}}"></script>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -41,7 +41,7 @@
 					<input type="hidden" id="hidden_consent_indicator" value="no">
 					<button id="student_sign_in_button" type="submit" class="btn btn-primary">Submit</button>
 				</div>
-				<div id="suggestions_container" class="list-group mt-2"></div>
+				<div id="suggestions_container" class="position-absolute col-9 col-lg-6 list-group mt-2"></div>
 			</form>
 		</div>
 	</div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,42 +1,44 @@
 {% extends "base.html" %}
 {% block content %}
-
-{% with messages = get_flashed_messages() %}
-    {% if messages %}
+<div class="vh-100 d-flex justify-content-center align-items-center">
+    <div class="border d-flex flex-column justify-content-center align-items-center py-5 px-2">
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
         <div class="alert alert-danger">
             {% for message in messages %}
-                <p>{{ message }}</p>
+            <p>{{ message }}</p>
             {% endfor %}
         </div>
-    {% endif %}
-{% endwith %}
+        {% endif %}
+        {% endwith %}
 
-<p>Welcome to UWAttend. Please log in to access the app.</p>
+        <p>Welcome to UWAttend. Please log in to access the app.</p>
 
-<form method="POST" novalidate>
-    {{ form.hidden_tag() }}
+        <form method="POST" novalidate>
+            {{ form.hidden_tag() }}
 
-    {{ form.username.label}}
-    {{ form.username }}
-    <br>
+            {{ form.username.label}}
+            {{ form.username }}
+            <br>
 
-    {% for error in form.username.errors %}
-    <span>{{ error }}</span><br>
-    {% endfor %}
+            {% for error in form.username.errors %}
+            <span>{{ error }}</span><br>
+            {% endfor %}
 
-    {{ form.password.label }}
-    {{ form.password }}
-    <br>
+            {{ form.password.label }}
+            {{ form.password }}
+            <br>
 
-    {% for error in form.password.errors %}
-    <span>{{ error }}</span><br>
-    {% endfor %}
+            {% for error in form.password.errors %}
+            <span>{{ error }}</span><br>
+            {% endfor %}
 
-    {{ form.remember_me() }} {{ form.remember_me.label}}
-    <br>
-    
-    {{ form.submit() }}
+            {{ form.remember_me() }} {{ form.remember_me.label}}
+            <br>
 
-</form>
+            {{ form.submit() }}
 
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,7 +3,10 @@
 <div class="vh-100 d-flex justify-content-center align-items-center bg-dark-subtle ">
     <!-- !!!Change colours to custom css!!! -->
     <div class="border rounded-4 bg-body shadow-lg d-flex flex-column 
-         justify-content-center align-items-center mb-3 py-5 px-5">
+         justify-content-center align-items-center mb-3 py-3 px-4">
+
+        <h3>Welcome to UWAttend!</h3>
+        <p>Please log in to access the app.</p>
 
         {% with messages = get_flashed_messages() %}
         {% if messages %}
@@ -15,34 +18,33 @@
         {% endif %}
         {% endwith %}
 
-        <h3>Welcome to UWAttend!</h3>
-        <p>Please log in to access the app.</p>
-
         <form method="POST" novalidate class="w-100">
             {{ form.hidden_tag() }}
-            <div class="mb-3">
+            <div class="mb-1">
                 {{ form.username.label(class="form-label")}}
                 {{ form.username(class="form-control") }}
 
-                {% for error in form.username.errors %}
-                <span class="form-text text-danger">{{ error }}</span><br>
+                {% for error in form.username.errors if form.username.errors %}
+                <span class="form-text text-danger">{{ error }}</span>
+                {% else %}
+                <span class="form-text invisible">No error</span>
                 {% endfor %}
             </div>
-            <div class="mb-3">
+            <div class="mb-1">
                 {{ form.password.label(class="form-label") }}
                 {{ form.password(class="form-control") }}
 
-                {% for error in form.password.errors %}
-                <span class="form-text text-danger">{{ error }}</span><br>
+                {% for error in form.password.errors if form.password.errors %}
+                <span class="form-text text-danger">{{ error }}</span>
+                {% else %}
+                <span class="form-text invisible">No error</span>
                 {% endfor %}
             </div>
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    {{ form.remember_me(class="form-check-input") }}
-                    {{ form.remember_me.label(class="form-check-label")}}
-                </div>
+            <div class="d-flex flex-column">
+                {{ form.submit(class="btn btn-success mb-2") }}
 
-                {{ form.submit(class="btn btn-success") }}
+                <!-- Replace href with forgot password logic -->
+                <a href="{{ url_for('login') }}">Forgot password?</a>
             </div>
 
         </form>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,16 +3,16 @@
 <div class="vh-100 d-flex justify-content-center align-items-center bg-dark-subtle ">
     <!-- !!!Change colours to custom css!!! -->
     <div class="border rounded-4 bg-body shadow-lg d-flex flex-column 
-         justify-content-center align-items-center mb-3 py-3 px-4">
+         justify-content-center align-items-center py-3 px-4">
 
         <h3>Welcome to UWAttend!</h3>
-        <p>Please log in to access the app.</p>
+        <p class="mb-2">Please log in to access the app.</p>
 
         {% with messages = get_flashed_messages() %}
         {% if messages %}
-        <div class="alert alert-danger">
+        <div class="alert alert-danger py-1 mb-3 text-center w-100">
             {% for message in messages %}
-            <p>{{ message }}</p>
+            {{ message }}
             {% endfor %}
         </div>
         {% endif %}
@@ -41,10 +41,10 @@
                 {% endfor %}
             </div>
             <div class="d-flex flex-column">
-                {{ form.submit(class="btn btn-success mb-2") }}
+                {{ form.submit(class="btn btn-success mb-3") }}
 
                 <!-- Replace href with forgot password logic -->
-                <a href="{{ url_for('login') }}">Forgot password?</a>
+                <a class="text-center mt" href="{{ url_for('login') }}">Forgot password?</a>
             </div>
 
         </form>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="vh-100 d-flex justify-content-center align-items-center bg-dark-subtle ">
+<div class="vh-100 d-flex justify-content-center align-items-center login-bg">
     <!-- !!!Change colours to custom css!!! -->
-    <div class="border rounded-4 bg-body shadow-lg d-flex flex-column 
+    <div class=" rounded-4 shadow-lg d-flex flex-column login-box
          justify-content-center align-items-center py-3 px-4">
 
         <h3>Welcome to UWAttend!</h3>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -5,7 +5,7 @@
     <div class=" rounded-4 shadow-lg d-flex flex-column login-box
          justify-content-center align-items-center py-3 px-4">
 
-        <h3>Welcome to UWAttend!</h3>
+        <h3 class="fw-bold">Welcome to UWAttend!</h3>
         <p class="mb-2">Please log in to access the app.</p>
 
         {% with messages = get_flashed_messages() %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="vh-100 d-flex justify-content-center align-items-center">
-    <div class="border d-flex flex-column justify-content-center align-items-center py-5 px-2">
+<div class="vh-100 d-flex justify-content-center align-items-center bg-dark-subtle ">
+    <!-- !!!Change colours to custom css!!! -->
+    <div class="border rounded-4 bg-body shadow-lg d-flex flex-column 
+         justify-content-center align-items-center mb-3 py-5 px-5">
+
         {% with messages = get_flashed_messages() %}
         {% if messages %}
         <div class="alert alert-danger">
@@ -12,31 +15,35 @@
         {% endif %}
         {% endwith %}
 
-        <p>Welcome to UWAttend. Please log in to access the app.</p>
+        <h3>Welcome to UWAttend!</h3>
+        <p>Please log in to access the app.</p>
 
-        <form method="POST" novalidate>
+        <form method="POST" novalidate class="w-100">
             {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.username.label(class="form-label")}}
+                {{ form.username(class="form-control") }}
 
-            {{ form.username.label}}
-            {{ form.username }}
-            <br>
+                {% for error in form.username.errors %}
+                <span class="form-text text-danger">{{ error }}</span><br>
+                {% endfor %}
+            </div>
+            <div class="mb-3">
+                {{ form.password.label(class="form-label") }}
+                {{ form.password(class="form-control") }}
 
-            {% for error in form.username.errors %}
-            <span>{{ error }}</span><br>
-            {% endfor %}
+                {% for error in form.password.errors %}
+                <span class="form-text text-danger">{{ error }}</span><br>
+                {% endfor %}
+            </div>
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    {{ form.remember_me(class="form-check-input") }}
+                    {{ form.remember_me.label(class="form-check-label")}}
+                </div>
 
-            {{ form.password.label }}
-            {{ form.password }}
-            <br>
-
-            {% for error in form.password.errors %}
-            <span>{{ error }}</span><br>
-            {% endfor %}
-
-            {{ form.remember_me() }} {{ form.remember_me.label}}
-            <br>
-
-            {{ form.submit() }}
+                {{ form.submit(class="btn btn-success") }}
+            </div>
 
         </form>
     </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -40,11 +40,11 @@
                 <span class="form-text invisible">No error</span>
                 {% endfor %}
             </div>
-            <div class="d-flex flex-column">
-                {{ form.submit(class="btn btn-success mb-3") }}
+            <div class="d-flex flex-column align-items-center">
+                {{ form.submit(class="btn btn-success mb-3 rounded-5 w-100") }}
 
                 <!-- Replace href with forgot password logic -->
-                <a class="text-center mt" href="{{ url_for('login') }}">Forgot password?</a>
+                <a class="" href="{{ url_for('login') }}">Forgot password?</a>
             </div>
 
         </form>

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -1,8 +1,8 @@
-<nav class="navbar sticky-top navbar-expand-md bg-dark-subtle">
+<nav class="navbar sticky-top navbar-expand-md">
 	<div class="container-fluid">
-		<a class="navbar-brand">UWAttend</a> <!-- Can likely be an image/gif later on -->
-		<span class="navbar-text fw-bold ms-auto me-2 d-md-none text-truncate w-25">
-			Username
+		<a class="navbar-brand">UWAttend</a>
+		<span class="navbar-text fw-bold ms-auto me-2 text-end d-md-none text-truncate w-25">
+			{{ current_user.uwaID }}
 		</span>
 		<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
 			aria-controls="navbarNav" aria-expanded="false" aria-label="navbar-toggler-icon">
@@ -19,20 +19,21 @@
 				</a>
 
 				<!-- Session Config: Visible to admins (1), coordinators (2), and facilitators (3) -->
-				
+
 				<a class="nav-link {% if request.path == url_for('session') %}active" aria-current="page{% endif %}"
-					href="{% if session['session_id']%}{{ url_for('updatesession')}}{% else %}{{ url_for('session') }}{% endif %}">Session Config</a>
-				
+					href="{% if session['session_id']%}{{ url_for('updatesession')}}{% else %}{{ url_for('session') }}{% endif %}">Session
+					Config</a>
+
 				<!-- Unit Config: Only visible to admins (1) and coordinators (2) -->
 				{% if current_user.userType == 1 or current_user.userType == 2 %}
-					<a class="nav-link {% if request.path == url_for('unitconfig') %}active" aria-current="page{% endif %}"
-						href="{{ url_for('unitconfig') }}">Unit Config</a>
+				<a class="nav-link {% if request.path == url_for('unitconfig') %}active" aria-current="page{% endif %}"
+					href="{{ url_for('unitconfig') }}">Unit Config</a>
 				{% endif %}
 
 				<!-- Administration: Only visible to admins (1) -->
 				{% if current_user.userType == 1 %}
-					<a class="nav-link {% if request.path == url_for('admin') %}active" aria-current="page{% endif %}"
-						href="{{ url_for('admin') }}">Administration</a>
+				<a class="nav-link {% if request.path == url_for('admin') %}active" aria-current="page{% endif %}"
+					href="{{ url_for('admin') }}">Administration</a>
 				{% endif %}
 			</div>
 

--- a/app/templates/signOut.html
+++ b/app/templates/signOut.html
@@ -1,5 +1,4 @@
-<div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel"
-	aria-hidden="true">
+<div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
 	<div class="modal-dialog modal-dialog-centered">
 		<div class="modal-content">
 			<div class="modal-header border-0 pb-0 d-flex justify-content-center ">

--- a/app/templates/student.html
+++ b/app/templates/student.html
@@ -33,26 +33,30 @@ endwith %}
             </div>
             <div class="row">
                 <div class="col-md-6">
-                    <div class="mb-3">
-                        {{ form.signInTime.label(class="form-label")}}
-                        {{ form.signInTime(class="form-control", type="time", step="1", value=student.signInTime) }}
-                    </div>
-                    <div class="mb-3">
-                        {{ form.signOutTime.label(class="form-label")}}
-                        {{ form.signOutTime(class="form-control", type="time", step="1", value=student.signOutTime) }}
+                    <div class="d-flex flex-md-column flex-row justify-content-between">
+                        <div class="mb-3 col-md-8 col-5">
+                            {{ form.signInTime.label(class="form-label")}}
+                            {{ form.signInTime(class="form-control", type="time", step="1", value=student.signInTime) }}
+                        </div>
+                        <div class="mb-3 col-md-8 col-5">
+                            {{ form.signOutTime.label(class="form-label")}}
+                            {{ form.signOutTime(class="form-control", type="time", step="1", value=student.signOutTime)
+                            }}
+                        </div>
                     </div>
                     <!-- Login Switch -->
                     <div class="d-flex gap-2 mb-3">
-                        {{form.login.label(class="form-label")}}
                         <input class="form-check-input" type="checkbox" name="login" id="login" {% if
                             student.login=='yes' %} checked {% endif %}>
+                        {{form.login.label(class="form-label")}}
+
                     </div>
 
                     <!-- Photo Switch -->
                     <div class="d-flex gap-2 mb-3">
-                        {{form.consent.label(class="form-label")}}
                         <input class="form-check-input" type="checkbox" name="consent" id="consent" {% if
                             student.consent=="yes" %} checked {% endif %}>
+                        {{form.consent.label(class="form-label")}}
                     </div>
                 </div>
 

--- a/app/templates/student.html
+++ b/app/templates/student.html
@@ -21,18 +21,18 @@ endwith %}
     <!-- Form element -->
     <form method="POST" action="{{ url_for('edit_student_details') }}">
         {{ form.hidden_tag() }}
-        <div class="mx-4 mt-3 mx-md-5">
-            <div class="mb-3 ">
-                <p>
-                    <strong>Student name:</strong> {{ student.name }}
-                </p>
-                <p>
-                    <strong>Student ID:</strong> {{ student.number }}
-                    {{ form.student_id(value=student.number) }}
-                </p>
-            </div>
+        <div class="mx-4 mt-3 mx-md-5 mb-5">
             <div class="row">
                 <div class="col-md-6">
+                    <div class="mb-3 ">
+                        <p>
+                            <strong>Student name:</strong> {{ student.name }}
+                        </p>
+                        <p>
+                            <strong>Student ID:</strong> {{ student.number }}
+                            {{ form.student_id(value=student.number) }}
+                        </p>
+                    </div>
                     <div class="d-flex flex-md-column flex-row justify-content-between">
                         <div class="mb-3 col-md-8 col-5">
                             {{ form.signInTime.label(class="form-label")}}
@@ -60,7 +60,7 @@ endwith %}
                     </div>
                 </div>
 
-                <div class="col-md-6 mb-5">
+                <div class="col-md-6 mb-4">
                     <!-- Grade Input -->
                     <div class="mb-3">
                         {{ form.grade.label(class="form-label")}}:
@@ -75,6 +75,11 @@ endwith %}
 
                     {{ form.comments.label(class="form-label")}}:
                     {{ form.comments(class="form-control", rows="5", **{"data-comment": student.comments}) }}
+                    <div class="d-flex justify-content-md-end justify-content-center">
+                        <button type="button" class="btn btn-danger w-50 mt-4" data-bs-toggle="modal"
+                            data-bs-target="#removeStudentModal">Remove
+                            Student</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -84,12 +89,10 @@ endwith %}
         </form> -->
 
         <!-- Action Buttons -->
-        <div class="fixed-bottom row mt-5">
-            <a href="{{ url_for('home') }}" class="btn btn-secondary col">Cancel</a>
-            <button type="submit" class="btn btn-success col">Save Changes</button>
-            <button type="button" class="btn btn-danger col" data-bs-toggle="modal"
-                data-bs-target="#removeStudentModal">Remove
-                Student</button>
+        <div class="fixed-bottom row d-flex justify-content-around mt-5 mb-3">
+            <a href="{{ url_for('home') }}" class="btn btn-secondary col-4">Cancel</a>
+            <button type="submit" class="btn btn-success col-4">Save Changes</button>
+
         </div>
     </form>
     {% include 'removeStudent.html'%}

--- a/app/templates/student.html
+++ b/app/templates/student.html
@@ -3,16 +3,16 @@
 
 <!-- Flash Messages -->
 {% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %} 
+{% if messages %}
 {% for category, message in messages %} {%if category == 'error'%}
 <div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
-	{{ message }}
-	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+    {{ message }}
+    <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>
 {% else %}
 <div class="alert alert-success alert-dismissable fade show d-flex justify-content-between" role="alert">
-	{{ message }}
-	<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+    {{ message }}
+    <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>
 {% endif %} {% endfor %} {% endif %} {%
 endwith %}
@@ -22,66 +22,70 @@ endwith %}
     <form method="POST" action="{{ url_for('edit_student_details') }}">
         {{ form.hidden_tag() }}
         <div class="mx-4 mt-3 mx-md-5">
-            <div class="mb-3">
-                <strong>Student name:</strong> {{ student.name }}
+            <div class="mb-3 ">
+                <p>
+                    <strong>Student name:</strong> {{ student.name }}
+                </p>
+                <p>
+                    <strong>Student ID:</strong> {{ student.number }}
+                    {{ form.student_id(value=student.number) }}
+                </p>
             </div>
-            <div class="mb-3">
-                <strong>Student ID:</strong> {{ student.number }}
-                {{ form.student_id(value=student.number) }}
-            </div>
-            <div class="mb-3">
-                <label for="sign_in_time" class="form-check-label">Sign in time:</label> 
-                {{ form.signInTime(class="form-control", type="time", step="1", value=student.signInTime) }}
-            </div>
-            <div class="mb-3">
-                <label for="sign_out_time" class="form-check-label">Sign out time:</label>
-                {{ form.signOutTime(class="form-control", type="time", step="1", value=student.signOutTime) }}
-            </div>
-        </div>
-        <div class="mx-4 mt-3 mx-md-5">
-            <!-- Login Switch -->
-            <div style="display:flex; gap: 1em;">
-                <label for="login" class="form-check-label">Login:</label>
-                <div class="mb-3 form-check">
-                    <input class="form-check-input" type="checkbox" name="login" id="login" {% if student.login == 'yes' %} checked {% endif %}>
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        {{ form.signInTime.label(class="form-label")}}
+                        {{ form.signInTime(class="form-control", type="time", step="1", value=student.signInTime) }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.signOutTime.label(class="form-label")}}
+                        {{ form.signOutTime(class="form-control", type="time", step="1", value=student.signOutTime) }}
+                    </div>
+                    <!-- Login Switch -->
+                    <div class="d-flex gap-2 mb-3">
+                        {{form.login.label(class="form-label")}}
+                        <input class="form-check-input" type="checkbox" name="login" id="login" {% if
+                            student.login=='yes' %} checked {% endif %}>
+                    </div>
+
+                    <!-- Photo Switch -->
+                    <div class="d-flex gap-2 mb-3">
+                        {{form.consent.label(class="form-label")}}
+                        <input class="form-check-input" type="checkbox" name="consent" id="consent" {% if
+                            student.consent=="yes" %} checked {% endif %}>
+                    </div>
+                </div>
+
+                <div class="col-md-6 mb-5">
+                    <!-- Grade Input -->
+                    <div class="mb-3">
+                        {{ form.grade.label(class="form-label")}}:
+                        {% if student.grade %}
+                        {{ form.grade(class="form-control", value=student.grade) }}
+                        {% else %}
+                        {{ form.grade(class="form-control") }}
+                        {% endif %}
+                    </div>
+                    <!-- Comment Section -->
+
+
+                    {{ form.comments.label(class="form-label")}}:
+                    {{ form.comments(class="form-control", rows="5", **{"data-comment": student.comments}) }}
                 </div>
             </div>
-            
-            <!-- Photo Switch -->
-            <div style="display:flex; gap: 1em;">
-                <label for="photo" class="form-check-label">Photo:</label>
-                <div class="mb-3 form-check">
-                    <input class="form-check-input" type="checkbox" name="consent" id="consent" {% if student.consent == "yes" %} checked {% endif %}>
-                </div>
-            </div>
-
-            <!-- Grade Input -->
-            <div class="mb-3">
-                <label for="grade" class="form-label">Grade:</label>
-                {% if student.grade %}
-                {{ form.grade(class="form-control", value=student.grade) }}
-                {% else %}
-                {{ form.grade(class="form-control") }}
-                {% endif %}
-            </div>
         </div>
-
-        <!-- Comment Section -->
-        <div class="mx-4 mt-3 mx-md-5">
-            <label for="comments" class="form-label">Leave a Comment:</label>
-            {{ form.comments(class="form-control", rows="3", **{"data-comment": student.comments}) }}
-        </div>
-
         <!-- <form id="remove_from_session_form" method="POST" action="{{ url_for('remove_from_session') }}" class="col">
             <button type="submit" id="remove_from_session" class="btn btn-danger">Remove From Session</button>
             <input type="hidden" name="student_id" value="{{ student.id }}">
         </form> -->
 
         <!-- Action Buttons -->
-        <div class="fixed-bottom row pb-2 bg-body">
+        <div class="fixed-bottom row mt-5">
             <a href="{{ url_for('home') }}" class="btn btn-secondary col">Cancel</a>
             <button type="submit" class="btn btn-success col">Save Changes</button>
-            <button type="button" class="btn btn-danger col" data-bs-toggle="modal" data-bs-target="#removeStudentModal">Remove Student</button>
+            <button type="button" class="btn btn-danger col" data-bs-toggle="modal"
+                data-bs-target="#removeStudentModal">Remove
+                Student</button>
         </div>
     </form>
     {% include 'removeStudent.html'%}


### PR DESCRIPTION
UPDATE: I have merged changes from my next lot into this (because it makes no sense to seperate them since they build on one another) - edit at the end of this message.

This is the first of a series of PRs to overhaul the frontend, I am spacing them out so as to not have one massive PR at the end.

This PR focuses on two main features - improving the format of the login page, and introducing basic css variables to allow easier colour customisation & compatibility with light/dark mode (read from browser using a media query).
I have used mostly the [default bootstrap variables](https://getbootstrap.com/docs/5.3/customize/css-variables/) in these, and have lightly modified the dark mode success to prove that my button overrides work.
Some example images (light mode)
![image](https://github.com/user-attachments/assets/e897d4c3-77af-4545-b812-358a7579cc7c)
![image](https://github.com/user-attachments/assets/ad185533-4c05-46d3-b3c8-7b2c59e96118)
(with empty field submission)
![image](https://github.com/user-attachments/assets/473102ea-2fc8-4920-a997-f1c617cb087f)
(invalid submission)

![image](https://github.com/user-attachments/assets/17d46200-8256-4952-a0d7-daf09c12ad0d)
Dark mode (read from browser by changing my browser preference)

Main things to test are:
- We are ok with format
- Functionality hasnt been broken by me (shouldn't be, but do check!)
- We understand how the css variables work so that if I come down with something/ go MIA before i can completely finish this, we understand how to use them, change them, etc.

Not linking this to the issue as it will still be open for a while longer.

EDIT: SECOND MERGE

I have improved the display of the home page, navbar, and student page.
Home page now will scroll inside the table element (HOPEFULLY!! it works for me? **please test**), dynamically sizing it using javascript so the overflow works as expected
Alerts disappear after a period of time
support for dark mode
Javascript to detect browser mode to switch un-customisable bootstrap elements (mainly the icons i.e. X on modal, Lines on mobile navbar) and switch them to the default bootstrap "dark mode"
![image](https://github.com/user-attachments/assets/82a3e69e-fdba-4e69-a460-05265d0443b4)

Somewhat experimental desktop design for student page:
![image](https://github.com/user-attachments/assets/4c8502c5-30f8-42dc-a469-7c9f16dafbfa)
Along with mildly more compact design for mobile
![image](https://github.com/user-attachments/assets/59ff1dfa-cca2-4064-af9b-89fdd4f55725)
