### PR TITLE
removed requirement for consent specified in student csv

### DIFF
--- a/app/utilities.py
+++ b/app/utilities.py
@@ -29,6 +29,15 @@ def read_csv_file(file_path):
 
 # Imports students into the database given a .csv file
 def import_student_in_db(data, unit_id):
+
+    unit = GetUnit(unitID=unit_id)
+
+    if not unit:
+        print("Student cannot be added to unit until unit is initialised")
+        return
+    
+    unit = unit[0]
+
     for record in data:
 
         student_number = record['Person ID']
@@ -44,7 +53,7 @@ def import_student_in_db(data, unit_id):
             title=record['Title'],
             preferredName=record['Preferred Given Name'],
             unitID=unit_id,  # Assuming a default unit ID, replace as needed
-            consent="no"  # Setting consent to no as per your requirements
+            consent='no' if unit.consent else 'not required' # Setting consent to no as per your requirements
         )
         print(f"Added student: {record['Given Names']} {record['Surname']} (ID: {student_number})")
 
@@ -74,7 +83,7 @@ def process_csvs(student_file_path, facilitator_file_path):
             # Import the data to the database
             #Ensure passed csv file is correct type 
             errors = []
-            if len(s_data[0]) != 6:
+            if len(s_data[0]) != 5:
                 print("Not a student csv!")
                 errors.append("Student csv format is incorrect")
             if len(f_data[0]) != 1:

--- a/test.csv
+++ b/test.csv
@@ -1,7 +1,7 @@
-Person ID,Surname,Title,Given Names,Preferred Given Name,Consent
-12345678,Duck,Mr,Daffy,Will,yes
-22345678,Roger,Mr.,Rabbit,Damian,yes
-32345678,Bunny,Dr.,Buggs,Asddddd,no
-12345652,Fffyffed,Mr,Fffffgg,Fffffgg,no
-12345653,aaa,Mr,Fffffgg,Fffffgg,no
-12345654,bbb,Mr,Fffffgg,Fffffgg,no
+Person ID,Surname,Title,Given Names,Preferred Given Name
+12345678,Duck,Mr,Daffy,Will
+22345678,Roger,Mr.,Rabbit,Damian
+32345678,Bunny,Dr.,Buggs,Asddddd
+12345652,Fffyffed,Mr,Fffffgg,Fffffgg
+12345653,aaa,Mr,Fffffgg,Fffffgg
+12345654,bbb,Mr,Fffffgg,Fffffgg


### PR DESCRIPTION
Small PR. Just made it so that the student.csv doesn't require a consent field anymore. 
Expected behaviour: if the unit coordinator doesn't tick the consent field when adding the unit, then student's consent field will be populated with not required in the database, otherwise if they do tick it then it will be no and all students will be prompted for consent at first sign in
I think I didn't break anything? Also I hope those are the expected values, not -1, 0, and 1. Wasn't 100% sure