### PR TITLE
44 sprint 2 download template for student csv

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -609,3 +609,15 @@ def sign_all_out():
 
     print("Successfully signed out all users")
     return flask.redirect(flask.url_for('home'))
+
+@app.route('/download_facilitator_template')
+def download_facilitator_template():
+    print("Sending facilitator template")
+    # Serve the facilitator template from the static folder or any desired directory
+    return flask.send_from_directory('static/files', 'facilitator_template.csv', as_attachment=True)
+
+@app.route('/download_student_template')
+def download_student_template():
+    print("Sending student template")
+    # Serve the student template from the static folder or any desired directory
+    return flask.send_from_directory('static/files', 'student_template.csv', as_attachment=True)

--- a/app/static/files/facilitator_template.csv
+++ b/app/static/files/facilitator_template.csv
@@ -1,0 +1,3 @@
+Facilitator Email
+facilitator1@uwa.edu.au
+facilitator2@gmail.com

--- a/app/static/files/student_template.csv
+++ b/app/static/files/student_template.csv
@@ -1,3 +1,3 @@
-Person ID,Surname,Title,Given Names,Preferred Given Names
+Student ID,Surname,Title,Given Names,Preferred Names
 12345678,Smith,Mr,Johnathon,John
 87654321,Doe,Ms,Jane,Jane

--- a/app/static/files/student_template.csv
+++ b/app/static/files/student_template.csv
@@ -1,0 +1,3 @@
+Person ID,Surname,Title,Given Names,Preferred Given Names
+12345678,Smith,Mr,Johnathon,John
+87654321,Doe,Ms,Jane,Jane

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -48,23 +48,35 @@ endwith %}
                 <div class="form-select-parent">
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
-
+                <div class="d-md-block d-none">
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-2">Download
+                        facilitator
+                        template</a>
+                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student
+                        template</a>
+                </div>
             </div>
-            <div class="col-md-4 col-12">
+            <div class="col-md-4 col-12 row">
                 {{ input(form.commentsuggestions) }}
-                {{ input(form.facilitatorfile, type="form-control-file w-100") }}
-                {{ input(form.studentfile, type="form-control-file w-100") }}
-
+                <div class="col-md-12 col-7">
+                    {{ input(form.facilitatorfile, type="form-control-file w-100") }}
+                    {{ input(form.studentfile, type="form-control-file w-100") }}
+                </div>
+                <div class="d-md-none d-block col-5">
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-2">Download
+                        facilitator
+                        template</a>
+                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student
+                        template</a>
+                </div>
             </div>
-            <div class="col-md-4 col-12">
-                <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">Download facilitator template</a>
-                <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student template</a>
-            </div>
-        </div>
 
-        <div class="d-flex justify-content-center mt-3">
-            {{ form.submit(class="btn btn-primary w-50" ) }}
         </div>
-    </form>
+</div>
+
+<div class="d-flex justify-content-center mt-3">
+    {{ form.submit(class="btn btn-primary w-50" ) }}
+</div>
+</form>
 </div>
 {% endblock %}

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -48,7 +48,7 @@ endwith %}
                 <div class="form-select-parent">
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
-                <div class="d-md-flex d-none gap-4">
+                <div class="d-md-flex justify-content-around d-none gap-4">
                     <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">Download
                         facilitator
                         template</a>

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -56,6 +56,10 @@ endwith %}
                 {{ input(form.studentfile, type="form-control-file w-100") }}
 
             </div>
+            <div class="col-md-4 col-12">
+                <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">Download facilitator template</a>
+                <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student template</a>
+            </div>
         </div>
 
         <div class="d-flex justify-content-center mt-3">

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -48,8 +48,8 @@ endwith %}
                 <div class="form-select-parent">
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
-                <div class="d-md-block d-none">
-                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-2">Download
+                <div class="d-md-flex d-none gap-4">
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">Download
                         facilitator
                         template</a>
                     <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -43,7 +43,8 @@
 						<input type="hidden" id="hidden_consent_indicator" value="no">
 						<button id="student_sign_in_button" type="submit" class="btn btn-primary">Submit</button>
 					</div>
-					<div id="suggestions_container" class="position-absolute col-9 col-lg-6 list-group mt-2"></div>
+					<div id="suggestions_container" class="position-absolute z-3 col-9 col-lg-6 list-group mt-2">
+					</div>
 				</form>
 			</div>
 		</div>


### PR DESCRIPTION
Added two buttons on the "add unit" page, so that a user can download a template for the student or facilitator csv. it's being served with flask's send from directory. will need to test this in the production environment eventually, as I don't know if it will force a different level of security that won't like how I'm prompting the download. 
If we want to change the templates or the sample data or anything, we just change the files in static/files later