### PR TITLE
129 sprint 3 session time suggestions

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -2,6 +2,22 @@ from datetime import datetime
 import pytz
 from flask_login import current_user
 
+sessionTimeDefinitions = {
+    "Morning" : (datetime.strptime('7:30', '%H:%M').time(), datetime.strptime('11:30', '%H:%M').time()),
+    "Afternoon" : (datetime.strptime('11:45', '%H:%M').time(), datetime.strptime('18:30', '%H:%M').time()),
+    "8am" : (datetime.strptime('7:45', '%H:%M').time(), datetime.strptime('8:15', '%H:%M').time()),
+    "9am" : (datetime.strptime('8:45', '%H:%M').time(), datetime.strptime('9:15', '%H:%M').time()),
+    "10am" : (datetime.strptime('9:45', '%H:%M').time(), datetime.strptime('10:15', '%H:%M').time()),
+    "11am" : (datetime.strptime('10:45', '%H:%M').time(), datetime.strptime('11:15', '%H:%M').time()),
+    "12pm" : (datetime.strptime('11:45', '%H:%M').time(), datetime.strptime('12:15', '%H:%M').time()),
+    "1pm" : (datetime.strptime('12:45', '%H:%M').time(), datetime.strptime('13:15', '%H:%M').time()),
+    "2pm" : (datetime.strptime('13:45', '%H:%M').time(), datetime.strptime('14:15', '%H:%M').time()),
+    "3pm" : (datetime.strptime('14:45', '%H:%M').time(), datetime.strptime('15:15', '%H:%M').time()),
+    "4pm" : (datetime.strptime('15:45', '%H:%M').time(), datetime.strptime('16:15', '%H:%M').time()),
+    "5pm" : (datetime.strptime('16:45', '%H:%M').time(), datetime.strptime('17:15', '%H:%M').time()),
+    "6pm" : (datetime.strptime('17:45', '%H:%M').time(), datetime.strptime('18:15', '%H:%M').time())
+}
+
 # Return the current Perth time
 def get_perth_time():
     utc_time = datetime.utcnow()
@@ -96,6 +112,16 @@ def set_updatesession_form_select_options(current_session, current_unit, form):
 
 def get_time_suggestion(session_times) :
 
+    current_time = get_perth_time().time()
+    print(f"current time: {current_time}")
+
+    for session_time in session_times :
+        if session_time in sessionTimeDefinitions :
+            if current_time >= sessionTimeDefinitions[session_time][0] and current_time <= sessionTimeDefinitions[session_time][1] :
+                print("suggesting {session_time} as likely time")
+                return session_time
+
+    print("no appropriate suggestions for time found")
     return None
 
 def generate_student_info(student, attendance_record):

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -53,10 +53,9 @@ def set_session_form_select_options(form):
         for name in session_names :
             session_name_choices.append((name, name))
 
-        # add empty session name default
-        session_name_choices.append(('', ''))
+        # add empty --Select-- session name default
+        session_name_choices.append(('', '--Select--'))
         form.session_name.default = ''
-        print(form.session_name.default)
 
         # get session times for first unit
         session_times = units[0].sessionTimes.split('|')
@@ -66,11 +65,9 @@ def set_session_form_select_options(form):
         time_suggestion = get_time_suggestion(session_times)
         
         if time_suggestion is None :
-            # add empty default
-            session_time_choices.append(('', ''))
+            # add empty --Select-- default
+            session_time_choices.append(('', '--Select--'))
             form.session_time.default = ''
-            print(form.session_time.default)
-
         else :
             form.session_time.default = time_suggestion
 
@@ -88,8 +85,6 @@ def set_session_form_select_options(form):
     form.session_date.default = get_perth_time()
 
     form.submit.label.text = "Configure"
-
-    form.process()
 
     form.process()
 
@@ -125,8 +120,6 @@ def set_updatesession_form_select_options(current_session, current_unit, form):
 
     form.process()
 
-    form.process()
-
 def get_time_suggestion(session_times) :
 
     current_time = get_perth_time().time()
@@ -135,7 +128,7 @@ def get_time_suggestion(session_times) :
     for session_time in session_times :
         if session_time in sessionTimeDefinitions :
             if current_time >= sessionTimeDefinitions[session_time][0] and current_time <= sessionTimeDefinitions[session_time][1] :
-                print("suggesting {session_time} as likely time")
+                print(f"suggesting {session_time} as likely time")
                 return session_time
 
     print("no appropriate suggestions for time found")

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -3,8 +3,8 @@ import pytz
 from flask_login import current_user
 
 sessionTimeDefinitions = {
-    "Morning" : (datetime.strptime('7:30', '%H:%M').time(), datetime.strptime('11:30', '%H:%M').time()),
-    "Afternoon" : (datetime.strptime('11:45', '%H:%M').time(), datetime.strptime('18:30', '%H:%M').time()),
+    "Morning" : (datetime.strptime('7:45', '%H:%M').time(), datetime.strptime('13:00', '%H:%M').time()),
+    "Afternoon" : (datetime.strptime('13:01', '%H:%M').time(), datetime.strptime('18:30', '%H:%M').time()),
     "8am" : (datetime.strptime('7:45', '%H:%M').time(), datetime.strptime('8:15', '%H:%M').time()),
     "9am" : (datetime.strptime('8:45', '%H:%M').time(), datetime.strptime('9:15', '%H:%M').time()),
     "10am" : (datetime.strptime('9:45', '%H:%M').time(), datetime.strptime('10:15', '%H:%M').time()),

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -25,12 +25,28 @@ def set_session_form_select_options(form):
         # get session names for first unit
         session_names = units[0].sessionNames.split('|')
         for name in session_names :
-            session_name_choices.append(name)
+            session_name_choices.append((name, name))
+
+        # add empty session name default
+        session_name_choices.append(('', ''))
+        form.session_name.default = ''
+        print(form.session_name.default)
 
         # get session times for first unit
         session_times = units[0].sessionTimes.split('|')
         for time in session_times :
-            session_time_choices.append(time)
+            session_time_choices.append((time, time))
+
+        time_suggestion = get_time_suggestion(session_times)
+        
+        if time_suggestion is None :
+            # add empty default
+            session_time_choices.append(('', ''))
+            form.session_time.default = ''
+            print(form.session_time.default)
+
+        else :
+            form.session_time.default = time_suggestion
 
         # set first unit as default
         form.unit.default = units[0].unitID
@@ -44,6 +60,8 @@ def set_session_form_select_options(form):
     form.session_time.choices = session_time_choices
 
     form.submit.label.text = "Create"
+
+    form.process()
 
 def set_updatesession_form_select_options(current_session, current_unit, form):
 
@@ -73,6 +91,12 @@ def set_updatesession_form_select_options(current_session, current_unit, form):
     form.session_time.default = current_session.sessionTime
 
     form.submit.label.text = "Update"
+
+    form.process()
+
+def get_time_suggestion(session_times) :
+
+    return None
 
 def generate_student_info(student, attendance_record):
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -544,7 +544,6 @@ def get_session_details(unitID) :
     # get session names for unit
     session_names = unit[0].sessionNames.split('|')
     session_name_choices = []
-    session_name_choices.append('')
 
     for name in session_names :
         session_name_choices.append(name)
@@ -556,13 +555,14 @@ def get_session_details(unitID) :
     session_time_default = get_time_suggestion(session_times) 
 
     if session_time_default is None :
-        session_time_default = ''
-        session_time_choices.append('')
+        session_time_default = '--Select--'
 
     for time in session_times :
         session_time_choices.append(time)
 
     print(f"Sending session details for {unit[0].unitCode}")
+
+    print(f"session time default: {session_time_default}")
 
     # send session details
     return flask.jsonify({'session_name_choices': session_name_choices, 'session_time_choices': session_time_choices, 'session_time_default': session_time_default})

--- a/app/routes.py
+++ b/app/routes.py
@@ -507,6 +507,7 @@ def get_session_details(unitID) :
     # get session names for unit
     session_names = unit[0].sessionNames.split('|')
     session_name_choices = []
+    session_name_choices.append('')
 
     for name in session_names :
         session_name_choices.append(name)
@@ -515,13 +516,19 @@ def get_session_details(unitID) :
     session_times = unit[0].sessionTimes.split('|')
     session_time_choices = []
 
+    session_time_default = get_time_suggestion(session_times) 
+
+    if session_time_default is None :
+        session_time_default = ''
+        session_time_choices.append('')
+
     for time in session_times :
         session_time_choices.append(time)
 
     print(f"Sending session details for {unit[0].unitCode}")
 
     # send session details
-    return flask.jsonify({'session_name_choices': session_name_choices, 'session_time_choices': session_time_choices})
+    return flask.jsonify({'session_name_choices': session_name_choices, 'session_time_choices': session_time_choices, 'session_time_default': session_time_default})
 
 @app.route('/student_suggestions', methods=['GET'])
 @login_required

--- a/app/routes.py
+++ b/app/routes.py
@@ -86,46 +86,49 @@ def session():
     # For JS formatting
     formatted_perth_time = perth_time.isoformat()
 
-    if form.validate_on_submit():
+    if flask.request.method == 'POST' :
+        if form.validate_on_submit():
 
-        # Handle form submission
-        unit_id = form.unit.data
-        session_name = form.session_name.data
-        session_time = form.session_time.data
-        session_date = form.session_date.data
+            # Handle form submission
+            unit_id = form.unit.data
+            session_name = form.session_name.data
+            session_time = form.session_time.data
+            session_date = form.session_date.data
 
-        # Printing for debugging
-        print(f"Session Name: {session_name}")
-        print(f"Session Time: {session_time}")
-        print(f"Unit Id: {unit_id}")
-        print(f"Session Date: {session_date}")
+            # Printing for debugging
+            print(f"Session Name: {session_name}")
+            print(f"Session Time: {session_time}")
+            print(f"Unit Id: {unit_id}")
+            print(f"Session Date: {session_date}")
 
-        # Check if the session already exists
-        current_session = GetUniqueSession(unit_id, session_name, session_time, session_date)
+            # Check if the session already exists
+            current_session = GetUniqueSession(unit_id, session_name, session_time, session_date)
 
-        if current_session is not None :
-            print("Session already exists.")
+            if current_session is not None :
+                print("Session already exists.")
+            else :
+                print("Session doesn't exist... creating new session.")
+                current_session = AddSession(unit_id, session_name, session_time, session_date)
+                if current_session is None :
+                    print("An error has occurred. The session was not created. Please try again.")
+                    return flask.redirect(flask.url_for('home'))
+
+            print("Current session details:")
+            print(f"Session name: {current_session.sessionName}")
+            print(f"Session time: {current_session.sessionTime}")
+            print(f"Session date: {current_session.sessionDate}")
+
+            flask.session['session_id'] = current_session.sessionID
+            print(f"Saving session id: {current_session.sessionID} to global variable")
+
+            # Redirect back to home page with the session ID as a query parameter
+            return flask.redirect(flask.url_for('home'))
         else :
-            print("Session doesn't exist... creating new session.")
-            current_session = AddSession(unit_id, session_name, session_time, session_date)
-            if current_session is None :
-                print("An error has occurred. The session was not created. Please try again.")
-                return flask.redirect(flask.url_for('home'))
-
-        print("Current session details:")
-        print(f"Session name: {current_session.sessionName}")
-        print(f"Session time: {current_session.sessionTime}")
-        print(f"Session date: {current_session.sessionDate}")
-
-        flask.session['session_id'] = current_session.sessionID
-        print(f"Saving session id: {current_session.sessionID} to global variable")
-
-        # Redirect back to home page with the session ID as a query parameter
-        return flask.redirect(flask.url_for('home'))
+            set_session_form_select_options(form)
+            return flask.render_template('session.html', form=form, perth_time=formatted_perth_time, update=False, errorMsg="Please select a valid option for all fields.")
 
     # set session form select field options
     set_session_form_select_options(form)
-
     return flask.render_template('session.html', form=form, perth_time=formatted_perth_time, update=False)
 
 @app.route('/updatesession', methods=['GET', 'POST'])

--- a/app/static/js/session_config.js
+++ b/app/static/js/session_config.js
@@ -21,7 +21,13 @@ function getSessionDetails() {
             }
             
             for (let session_time of data.session_time_choices) {
-                session_time_optionHTML += `<option value="${session_time}">${session_time}</option>`
+                if (session_time == data.session_time_default) {
+                    session_time_optionHTML += `<option selected value="${session_time}">${session_time}</option>`
+                }
+                else {
+                    session_time_optionHTML += `<option value="${session_time}">${session_time}</option>`
+                }
+                
             }
 
             // inserts the HTML

--- a/app/static/js/session_config.js
+++ b/app/static/js/session_config.js
@@ -19,6 +19,9 @@ function getSessionDetails() {
             for (let session_name of data.session_name_choices) {
                 session_name_optionHTML += `<option value="${session_name}">${session_name}</option>`
             }
+
+            // add default --select-- to session names
+            session_name_optionHTML += `<option selected value="">--Select--</option>`
             
             for (let session_time of data.session_time_choices) {
                 if (session_time == data.session_time_default) {
@@ -27,7 +30,9 @@ function getSessionDetails() {
                 else {
                     session_time_optionHTML += `<option value="${session_time}">${session_time}</option>`
                 }
-                
+            }
+            if (data.session_time_default == '--Select--') {
+                session_time_optionHTML += `<option selected value="">--Select--</option>`
             }
 
             // inserts the HTML

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -49,7 +49,5 @@
 
 </form>
 </div>
-{% if update %}
 <script src="{{url_for('static', filename='js/session_config.js')}}"></script>
-{% endif %}
 {% endblock %}

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -25,15 +25,6 @@
                 <div class="form-select-parent">
                     {{ field(class="form-select") }}
 
-                    {% for error in field.errors if field.errors %}
-                    <span class="form-text text-danger">{{ error }}</span>
-                    <!-- Elif breaks jinja fsr -->
-                    {% else %}
-                    {% if type != "form-check-input" %}
-                    <span class="form-text invisible">No error</span>
-                    {% endif %}
-                    {% endfor %}
-
                 </div>
             </div>
             {% endif %}

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -38,6 +38,14 @@
                 <input type="hidden" id="current_time" name="current_time">
             </div>
 
+            <div class="mt-2 row d-flex justify-content-around">
+            {% if errorMsg %}
+            <span class="text-center form-text text-danger">{{ errorMsg }}</span>
+            {% else %}
+            <span class="form-text invisible">No error</span>
+            {% endif %}
+            </div>
+
             <!-- Buttons -->
             <div class="mt-2 row d-flex justify-content-around">
                 {% if update %}

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -24,6 +24,16 @@
                 {{ field.label(class="form-label text-end") }}
                 <div class="form-select-parent">
                     {{ field(class="form-select") }}
+
+                    {% for error in field.errors if field.errors %}
+                    <span class="form-text text-danger">{{ error }}</span>
+                    <!-- Elif breaks jinja fsr -->
+                    {% else %}
+                    {% if type != "form-check-input" %}
+                    <span class="form-text invisible">No error</span>
+                    {% endif %}
+                    {% endfor %}
+
                 </div>
             </div>
             {% endif %}

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -18,22 +18,12 @@
         <div>
             {{ form.hidden_tag() }}
             {% for field in form%}
-            {% if field.type == "SelectField" %}
+            {% if field.type == "SelectField" or field.type == "DateField" %}
 
             <div class="mb-4 d-flex justify-content-between align-items-center gap-3">
                 {{ field.label(class="form-label text-end") }}
                 <div class="form-select-parent">
                     {{ field(class="form-select") }}
-
-                </div>
-            </div>
-            {% endif %}
-
-            {% if field.type == "DateField" %}
-            <div class="mb-4 d-flex justify-content-between align-items-center gap-3">
-                {{ field.label(class="form-label text-end") }}
-                <div class="form-select-parent">
-                    {{ field(class="form-control") }}
                 </div>
             </div>
             {% endif %}


### PR DESCRIPTION
Changes in this PR:
Added session time suggestions based on the current time
Added --Select-- defaults to session name and session time (if there isn't a suggested time as the default)
Added an error message to say that valid options must be selected, in the case where --Select-- is picked and submitted (feel free to change where this is, I tried putting it up the top but the spacing was off)
Also fixed the bug where if you have multiple units, it wasn't correctly changing the available times and names when toggling between the units

Annoying things:
If there is a mistake with the form (which will most definitely be the user trying to input with --Select-- , which will obvi fail), the page is reloaded but the form is reset, and the previous inputs by the user are not preserved. This isn't that bad, although a bit weird esp when there are multiple units to select from as it can change back to the first unit (however Adrian has said there probably won't be many users with multiple units). I have tried for so long to change this without success (it's difficult because all the form inputs are dynamically defined), so am giving up and will create a low priority issue for it (so probs won't get done).
For this reason I haven't displayed any field-specific error messages (ones that come under the field where --Select-- had been selected and say that this field is required). Because I feel like it's a bit weird to have that in the cases where the form resets, esp to a different unit.

I feel like these things aren't too bad considering users will def know they can't pick the --Select-- option and that this will probs only happen by accident, not them actually trying to select it (so the error message doesn't need to be that helpful), and also that most will have just one unit so the form resetting isn't that bad.