### PR TITLE
143 improve session occurence and comments

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -72,8 +72,8 @@ class AddUnitForm(FlaskForm):
     consentcheck = BooleanField('Photo Consent Required?')
     assessmentcheck = BooleanField('Sessions Assessed?')
     commentsenabled = BooleanField('Comments Enabled?')
-    sessionnames = StringField('Session Names:', validators=[DataRequired()], render_kw={"placeholder":"Separate with | (e.g. Lab|Workshop|Tutorial)"})
-    sessions = HiddenField("Sessions")
+    sessionnames = StringField('Session Names:', render_kw={"placeholder":"Enter sessions by pressing enter"})
+    sessions = HiddenField("Sessions", validators=[DataRequired()])
     sessionoccurence = SelectField(
 		'Session Occurence',
 		choices=[('Morning/Afternoon','Morning/Afternoon'), ('Hours', 'Hours')],

--- a/app/forms.py
+++ b/app/forms.py
@@ -72,13 +72,13 @@ class AddUnitForm(FlaskForm):
     consentcheck = BooleanField('Photo Consent Required?')
     assessmentcheck = BooleanField('Sessions Assessed?')
     commentsenabled = BooleanField('Comments Enabled?')
-    sessionnames = StringField('Session Names:', render_kw={"placeholder":"Enter sessions by pressing enter"})
+    sessionnames = StringField('Session Names:', render_kw={"placeholder":"Add sessions"})
     sessions = HiddenField("Sessions", validators=[DataRequired()])
     sessionoccurence = SelectField(
 		'Session Occurence',
 		choices=[('Morning/Afternoon','Morning/Afternoon'), ('Hours', 'Hours')],
 		validators=[DataRequired()], validate_choice=False)
-    commentsuggestions = StringField('Comment Suggestions:', render_kw={"placeholder":"Optional; separate with |"})
+    commentsuggestions = StringField('Comment Suggestions:', render_kw={"placeholder":"Optional, add suggestions"})
     comments = HiddenField("Comments")
     submit = SubmitField('Add Unit')
     

--- a/app/forms.py
+++ b/app/forms.py
@@ -73,11 +73,13 @@ class AddUnitForm(FlaskForm):
     assessmentcheck = BooleanField('Sessions Assessed?')
     commentsenabled = BooleanField('Comments Enabled?')
     sessionnames = StringField('Session Names:', validators=[DataRequired()], render_kw={"placeholder":"Separate with | (e.g. Lab|Workshop|Tutorial)"})
+    sessions = HiddenField("Sessions")
     sessionoccurence = SelectField(
 		'Session Occurence',
 		choices=[('Morning/Afternoon','Morning/Afternoon'), ('Hours', 'Hours')],
 		validators=[DataRequired()], validate_choice=False)
     commentsuggestions = StringField('Comment Suggestions:', render_kw={"placeholder":"Optional; separate with |"})
+    comments = HiddenField("Comments")
     submit = SubmitField('Add Unit')
     
 class StudentSignInForm(FlaskForm):

--- a/app/routes.py
+++ b/app/routes.py
@@ -242,10 +242,10 @@ def addunit():
         student_file = form.studentfile.data
         facilitator_file = form.facilitatorfile.data
         sessionnames = form.sessionnames.data
-        sessionoccurence = form.sessionoccurence.data
+        sessionoccurence = form.sessionoccurence.data #AND THIS ONE
         assessmentcheck = form.assessmentcheck.data
         commentsenabled = form.commentsenabled.data
-        commentsuggestions = form.commentsuggestions.data
+        commentsuggestions = form.commentsuggestions.data #WANT THIS ONE
 
         #Validation occurs in flask forms with custom validators
         

--- a/app/routes.py
+++ b/app/routes.py
@@ -241,11 +241,13 @@ def addunit():
         end_date = form.enddate.data
         student_file = form.studentfile.data
         facilitator_file = form.facilitatorfile.data
-        sessionnames = form.sessionnames.data
-        sessionoccurence = form.sessionoccurence.data #AND THIS ONE
+        sessionnames = form.sessions.data
+        sessionoccurence = form.sessionoccurence.data 
         assessmentcheck = form.assessmentcheck.data
         commentsenabled = form.commentsenabled.data
-        commentsuggestions = form.commentsuggestions.data #WANT THIS ONE
+        commentsuggestions = form.comments.data 
+
+        print(sessionnames, commentsuggestions) #Checking hidden form works
 
         #Validation occurs in flask forms with custom validators
         

--- a/app/routes.py
+++ b/app/routes.py
@@ -247,7 +247,7 @@ def addunit():
         commentsenabled = form.commentsenabled.data
         commentsuggestions = form.comments.data 
 
-        print(sessionnames, commentsuggestions) #Checking hidden form works
+        print(f"session string: " + sessionnames + "; commentString: " + commentsuggestions) #Checking hidden form works
 
         #Validation occurs in flask forms with custom validators
         

--- a/app/static/js/add_unit.js
+++ b/app/static/js/add_unit.js
@@ -18,18 +18,37 @@ function removeSessions(thisObj) {
 	$("#sessions").val(newString)
 }
 
+
+function removeComments(thisObj) {
+	commentText = thisObj.attr("id");
+	commentsArray = $("#comments").val().split("|");
+	console.log(commentsArray)
+	index = commentsArray.indexOf(commentText)
+	commentsArray.splice(index, 1)
+	newString = commentsArray.join("|")
+	console.log(newString)
+	thisObj.fadeOut("fast", "linear", function () { thisObj.remove(); });
+	$("#comments").val(newString)
+}
+
 $(window).on("load", function () {
 	if ($("#commentsenabled").prop("checked")) {
-		$("#comment-suggestions-parent").removeClass("d-none")
+		$("#comment-suggestions-parent").removeClass("d-none");
 	} else {
-		$("#comment-suggestions-parent").addClass("d-none")
+		$("#comment-suggestions-parent").addClass("d-none");
 	}
 
 	//Load any data in hidden forms
-	sessionsArray = $("#sessions").val().split("|")
+	sessionsArray = $("#sessions").val().split("|");
 	sessionsArray.forEach(element => {
 		newBadge = $("<span class='badge session-badge p-2' id='" + element + "'></span>").text(element);
 		$("#sessions-container").append(newBadge);
+	});
+
+	commentsArray = $("#comments").val().split("|");
+	commentsArray.forEach(element => {
+		newBadge = $("<span class='badge comment-badge p-2' id='" + element + "'></span>").text(element);
+		$("#comments-container").append(newBadge);
 	});
 })
 
@@ -60,5 +79,33 @@ $(document).ready(function () {
 
 	$(".session-badge").on("click", function () {
 		removeSessions($(this));
+	})
+
+	//Input for comments
+	$("#commentsuggestions").on("keypress", function (e) {
+		if (e.which == 13) {
+			e.preventDefault();
+			if ($("#commentsuggestions").val()) {
+				curr = $("#comments").val();
+				input = $("#commentsuggestions").val()
+				curr = curr + "|" + input;
+				$("#commentsuggestions").val("");
+				//remove redundant |
+				if (curr.charAt(0) === '|') {
+					curr = curr.substring(1);
+				}
+				$("#comments").val(curr);
+				console.log($("#comments").val());
+				newBadge = $("<span class='badge comment-badge p-2' id='" + input + "'></span>").text(input);
+				newBadge.on("click", function () {
+					removeComments($(this));
+				})
+				$("#comments-container").append(newBadge);
+			}
+		}
+	})
+
+	$(".comment-badge").on("click", function () {
+		removeComments($(this));
 	})
 })

--- a/app/static/js/add_unit.js
+++ b/app/static/js/add_unit.js
@@ -6,10 +6,56 @@ $("#commentsenabled").change(function () {
 	}
 })
 
+function removeSessions(thisObj) {
+	sessionText = thisObj.attr("id");
+	sessionsArray = $("#sessions").val().split("|");
+	index = sessionsArray.indexOf(sessionText)
+	sessionsArray.splice(index, 1)
+	newString = sessionsArray.join("|")
+	console.log(newString)
+	thisObj.fadeOut("fast", "linear", function () { thisObj.remove(); });
+	$("#sessions").val(newString)
+}
+
 $(window).on("load", function () {
 	if ($("#commentsenabled").prop("checked")) {
 		$("#comment-suggestions-parent").removeClass("d-none")
 	} else {
 		$("#comment-suggestions-parent").addClass("d-none")
 	}
+
+	sessionsArray = $("#sessions").val().split("|")
+	sessionsArray.forEach(element => {
+		newBadge = $("<span class='badge session-badge p-2' id='" + element + "'></span>").text(element);
+		$("#sessions-container").append(newBadge);
+	});
+})
+
+$(document).ready(function () {
+	$("#sessionnames").on("keypress", function (e) {
+		if (e.which == 13) {
+			e.preventDefault();
+			if ($("#sessionnames").val()) {
+				curr = $("#sessions").val();
+				input = $("#sessionnames").val()
+				curr = curr + "|" + input;
+				$("#sessionnames").val("");
+				//remove redundant |
+				if (curr.charAt(0) === '|') {
+					curr = curr.substring(1);
+				}
+				$("#sessions").val(curr);
+				console.log($("#sessions").val());
+				newBadge = $("<span class='badge session-badge p-2' id='" + input + "'></span>").text(input);
+				newBadge.on("click", function () {
+					removeSessions($(this));
+				})
+				$("#sessions-container").append(newBadge);
+			}
+		}
+	})
+
+	$(".session-badge").on("click", function () {
+		removeSessions($(this));
+	})
 })

--- a/app/static/js/add_unit.js
+++ b/app/static/js/add_unit.js
@@ -9,6 +9,7 @@ $("#commentsenabled").change(function () {
 function removeSessions(thisObj) {
 	sessionText = thisObj.attr("id");
 	sessionsArray = $("#sessions").val().split("|");
+	console.log(sessionsArray)
 	index = sessionsArray.indexOf(sessionText)
 	sessionsArray.splice(index, 1)
 	newString = sessionsArray.join("|")
@@ -24,6 +25,7 @@ $(window).on("load", function () {
 		$("#comment-suggestions-parent").addClass("d-none")
 	}
 
+	//Load any data in hidden forms
 	sessionsArray = $("#sessions").val().split("|")
 	sessionsArray.forEach(element => {
 		newBadge = $("<span class='badge session-badge p-2' id='" + element + "'></span>").text(element);
@@ -32,6 +34,7 @@ $(window).on("load", function () {
 })
 
 $(document).ready(function () {
+	//Input for session names
 	$("#sessionnames").on("keypress", function (e) {
 		if (e.which == 13) {
 			e.preventDefault();

--- a/app/static/js/add_unit.js
+++ b/app/static/js/add_unit.js
@@ -9,11 +9,9 @@ $("#commentsenabled").change(function () {
 function removeSessions(thisObj) {
 	sessionText = thisObj.attr("id");
 	sessionsArray = $("#sessions").val().split("|");
-	console.log(sessionsArray)
 	index = sessionsArray.indexOf(sessionText)
 	sessionsArray.splice(index, 1)
 	newString = sessionsArray.join("|")
-	console.log(newString)
 	thisObj.fadeOut("fast", "linear", function () { thisObj.remove(); });
 	$("#sessions").val(newString)
 }
@@ -22,11 +20,9 @@ function removeSessions(thisObj) {
 function removeComments(thisObj) {
 	commentText = thisObj.attr("id");
 	commentsArray = $("#comments").val().split("|");
-	console.log(commentsArray)
 	index = commentsArray.indexOf(commentText)
 	commentsArray.splice(index, 1)
 	newString = commentsArray.join("|")
-	console.log(newString)
 	thisObj.fadeOut("fast", "linear", function () { thisObj.remove(); });
 	$("#comments").val(newString)
 }
@@ -67,7 +63,6 @@ $(document).ready(function () {
 					curr = curr.substring(1);
 				}
 				$("#sessions").val(curr);
-				console.log($("#sessions").val());
 				newBadge = $("<span class='badge session-badge p-2' id='" + input + "'></span>").text(input);
 				newBadge.on("click", function () {
 					removeSessions($(this));
@@ -95,7 +90,6 @@ $(document).ready(function () {
 					curr = curr.substring(1);
 				}
 				$("#comments").val(curr);
-				console.log($("#comments").val());
 				newBadge = $("<span class='badge comment-badge p-2' id='" + input + "'></span>").text(input);
 				newBadge.on("click", function () {
 					removeComments($(this));

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -201,3 +201,18 @@ body {
   --bs-btn-active-bg: color-mix(in srgb, var(--danger), black 25%);
   --bs-btn-active-border-color: color-mix(in srgb, var(--danger), black 25%);
 }
+
+/* Badges */
+
+.badge {
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  color: var(--text);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in-out;
+}
+
+/* Badge hover state */
+.badge:hover {
+  background-color: color-mix(in srgb, var(--secondary) 50%, white 30%);
+}

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -59,29 +59,33 @@ endwith %}
                         Download student template</a>
                 </div>
             </div>
-            <div class="col-md-4 col-12 row ">
+            <div class="col-md-4 col-12">
                 <div class="form-select-parent d-none d-md-block">
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
-                <div class="col-md-12 col-7">
-                    {{ input(form.facilitatorfile, type="form-control-file w-100") }}
-                    {{ input(form.studentfile, type="form-control-file w-100") }}
-                </div>
-                <div class="d-md-none d-block col-5 ">
-                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-5">
-                        Download facilitator template</a>
-                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">
-                        Download student template</a>
+                <div class="d-flex flex-row flex-md-column gap-3">
+                    <div>
+                        {{ input(form.facilitatorfile, type="form-control-file") }}
+                        <div class="d-md-none d-block mt-4">
+                            <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-5">
+                                Download facilitator template</a>
+                        </div>
+                    </div>
+                    <div>
+                        {{ input(form.studentfile, type="form-control-file") }}
+                        <div class="d-md-none d-block mt-4">
+                            <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">
+                                Download student template</a>
+                        </div>
+                    </div>
                 </div>
             </div>
-
         </div>
-</div>
 
-<div class="d-flex justify-content-center mt-3">
-    {{ form.submit(class="btn btn-primary w-50" ) }}
-</div>
-</form>
+        <div class="d-flex justify-content-center mt-0">
+            {{ form.submit(class="btn btn-primary w-50" ) }}
+        </div>
+    </form>
 </div>
 
 <script src="{{ url_for('static', filename='js/add_unit.js') }}"></script> {% endblock %}

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -64,11 +64,10 @@ endwith %}
                     {{ input(form.studentfile, type="form-control-file w-100") }}
                 </div>
                 <div class="d-md-none d-block col-5">
-                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-2">Download
-                        facilitator
-                        template</a>
-                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student
-                        template</a>
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">
+                        Download facilitator template</a>
+                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">
+                        Download student template</a>
                 </div>
             </div>
 

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -45,9 +45,16 @@ endwith %}
             </div>
             <div class="col-md-4 col-6">
                 <div id="session-names-parent">
-                    {{ input(form.sessionnames) }}
-                    <div class="mb-3 d-flex flex-wrap gap-2" id="sessions-container"></div>
+                    {{ form.sessionnames.label(class="form-label") }}
+                    {{ form.sessionnames(class="form-control")}}
+                    {% for error in form.sessions.errors if form.sessions.errors %}
+                    <span class="form-text text-danger">{{ error }}</span>
+                    {% else %}
+                    <span class="form-text invisible">No error</span>
+                    {% endfor %}
                     {{ form.sessions()}}
+                    <div class="mb-3 d-flex flex-wrap gap-2" id="sessions-container"></div>
+
                 </div>
                 <div class="form-select-parent d-md-none d-block">
                     {{ input(form.sessionoccurence, type="form-select") }}

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -62,6 +62,7 @@ endwith %}
                 <div class="d-none" id="comment-suggestions-parent">
                     {{ input(form.commentsuggestions) }}
                     {{ form.comments() }}
+                    <div class="mb-3 d-flex flex-wrap gap-2" id="comments-container"></div>
                 </div>
 
                 <div class="d-md-flex justify-content-around d-none gap-4">
@@ -94,7 +95,7 @@ endwith %}
             </div>
         </div>
 
-        <div class="d-flex justify-content-center mt-0">
+        <div class="d-flex justify-content-center mt-4">
             {{ form.submit(class="btn btn-primary w-50" ) }}
         </div>
     </form>

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -45,26 +45,30 @@ endwith %}
             </div>
             <div class="col-md-4 col-6">
                 {{ input(form.sessionnames) }}
-
+                <div class="form-select-parent d-md-none d-block">
+                    {{ input(form.sessionoccurence, type="form-select") }}
+                </div>
                 <div class="d-none" id="comment-suggestions-parent">
                     {{ input(form.commentsuggestions) }}
                 </div>
+
                 <div class="d-md-flex justify-content-around d-none gap-4">
-                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">Download
-                        facilitator
-                        template</a>
-                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">Download student
-                        template</a>
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary ">
+                        Download facilitator template</a>
+                    <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">
+                        Download student template</a>
                 </div>
             </div>
-            <div class="col-md-4 col-12 row">
-                {{ input(form.commentsuggestions) }}
+            <div class="col-md-4 col-12 row ">
+                <div class="form-select-parent d-none d-md-block">
+                    {{ input(form.sessionoccurence, type="form-select") }}
+                </div>
                 <div class="col-md-12 col-7">
                     {{ input(form.facilitatorfile, type="form-control-file w-100") }}
                     {{ input(form.studentfile, type="form-control-file w-100") }}
                 </div>
-                <div class="d-md-none d-block col-5">
-                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary">
+                <div class="d-md-none d-block col-5 ">
+                    <a href="{{ url_for('download_facilitator_template') }}" class="btn btn-secondary mb-5">
                         Download facilitator template</a>
                     <a href="{{ url_for('download_student_template') }}" class="btn btn-secondary">
                         Download student template</a>

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -46,7 +46,8 @@ endwith %}
             <div class="col-md-4 col-6">
                 <div id="session-names-parent">
                     {{ form.sessionnames.label(class="form-label") }}
-                    {{ form.sessionnames(class="form-control")}}
+                    {{ form.sessionnames(class="form-control", **{'data-bs-toggle':"tooltip",
+                    'data-bs-title':"Input session, and press enter to add", 'data-bs-custom-class':"custom-tooltip"})}}
                     {% for error in form.sessions.errors if form.sessions.errors %}
                     <span class="form-text text-danger">{{ error }}</span>
                     {% else %}
@@ -60,7 +61,7 @@ endwith %}
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
                 <div class="d-none" id="comment-suggestions-parent">
-                    {{ input(form.commentsuggestions) }}
+                    {{ input(form.commentsuggestions, tooltip="Input suggestions, and press enter to add") }}
                     {{ form.comments() }}
                     <div class="mb-3 d-flex flex-wrap gap-2" id="comments-container"></div>
                 </div>

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -44,12 +44,17 @@ endwith %}
                 {{ input(form.commentsenabled, type="form-check-input") }}
             </div>
             <div class="col-md-4 col-6">
-                {{ input(form.sessionnames) }}
+                <div id="session-names-parent">
+                    {{ input(form.sessionnames) }}
+                    <div class="mb-3 d-flex flex-wrap gap-2" id="sessions-container"></div>
+                    {{ form.sessions()}}
+                </div>
                 <div class="form-select-parent d-md-none d-block">
                     {{ input(form.sessionoccurence, type="form-select") }}
                 </div>
                 <div class="d-none" id="comment-suggestions-parent">
                     {{ input(form.commentsuggestions) }}
+                    {{ form.comments() }}
                 </div>
 
                 <div class="d-md-flex justify-content-around d-none gap-4">


### PR DESCRIPTION
Now instead of a | string, pressing enter after inputting a session / comment suggestion adds a badge and inserts the element into a hidden form. Form validates correctly using this hidden form (to my limited testing). 
Formatting breaks a bit, unfortunately, but I don't care enough to try and fix it. It's sufficient.

Uses the badges CSS from a different PR (also mine), shouldn't cause conflicts as its a straight copy paste from that PR so they should merge together.
![image](https://github.com/user-attachments/assets/b3440389-9ecf-40a3-a01a-88b7c98b1ca5)


Unrelated fun fact! naming the branch after the issue causes git to implode, i believe due to the | character in its name. Was annoying to troubleshoot but just creating a seperate branch seems to have fixed it for me!
