### PR TITLE
188 fix add unit bug in cases where csvs are not correct

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -52,10 +52,13 @@ def password_check(form, field):
     if form.password1.data != form.password2.data:
         raise ValidationError("Passwords do not match")
 
+
 def date_check(form, field):
-	print(f"checking date validity, {form.startdate.data}, {form.enddate.data}")
-	if form.startdate.data > form.enddate.data:
-		raise ValidationError("Start date must be before end date")
+    print(f"checking date validity, {form.startdate.data}, {form.enddate.data}")
+    if form.startdate.data is not None and form.enddate.data is not None :
+        if form.startdate.data > form.enddate.data :
+            raise ValidationError("Start date must be before end date")
+
     
 def is_student_num(form, field):
     if len(form.studentNumber.data) != 8 and not any(c.isdigit() for c in form.studentNumber.data):

--- a/app/routes.py
+++ b/app/routes.py
@@ -584,6 +584,9 @@ def addunit():
         unit_id = AddUnit(newunit_code, unit_name, semester, start_date, end_date, 
                 sessionnames, occurences, commentsenabled , assessmentcheck, consent_required, commentsuggestions )
         
+        AddUnitToFacilitator(current_user.email, unit_id)
+        AddUnitToCoordinator(current_user.email, unit_id)
+        
         #Add from csv
         #TODO: handle emailing facilitators - should go in the correct process csv function
         import_student_in_db(s_data, unit_id)
@@ -591,8 +594,6 @@ def addunit():
         if error == 0:
             flask.flash("Error, invalid email address in facilitators", 'error')
             return flask.render_template('addunit.html', form=form)
-        AddUnitToFacilitator(current_user.email, unit_id)
-        AddUnitToCoordinator(current_user.email, unit_id)
         
         return flask.redirect(flask.url_for('unitconfig'))
 	    

--- a/app/routes.py
+++ b/app/routes.py
@@ -592,7 +592,7 @@ def addunit():
         import_student_in_db(s_data, unit_id)
         error = import_facilitator_in_db(f_data, unit_id, current_user)
         if error == 0:
-            flask.flash("Error, invalid email address in facilitators", 'error')
+            flask.flash("Invalid email address in facilitators csv. The unit has been uploaded but check facilitators", 'error')
             return flask.render_template('addunit.html', form=form)
         
         return flask.redirect(flask.url_for('unitconfig'))

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -74,5 +74,5 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
 
 //Closes an alert 3 seconds after it pops up
 setTimeout(function () {
-    $('.alert:not(#serverAlert)').alert('close');
+    $('.alert:not(#serverAlert,#addUnitErrorMsgAlert)').alert('close');
 }, 3000); 

--- a/app/templates/addunit.html
+++ b/app/templates/addunit.html
@@ -6,7 +6,7 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% if messages %}
 {% for category, message in messages %} {%if category == 'error'%}
-<div class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
+<div id=addUnitErrorMsgAlert class="alert alert-danger alert-dismissable fade show d-flex justify-content-between" role="alert">
     {{ message }}
     <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>

--- a/app/utilities.py
+++ b/app/utilities.py
@@ -91,16 +91,13 @@ def process_csvs(student_file_path, facilitator_file_path):
         if s_data and f_data:
             # Import the data to the database
             #Ensure passed csv file is correct type 
-            errors = []
-            if len(s_data[0]) != 5:
-                print("Not a student csv!")
-                errors.append("Student csv format is incorrect")
-            if len(f_data[0]) != 1:
-                print("Not a facilitator csv!")
-                errors.append("Facilitator csv format is incorrect")
+            errors = validate_csv_headers(s_data[0], f_data[0])
+
             if errors:
-                msg = errors[0] if len(errors) == 1 else errors[0] + ", " + errors[1]
-                return 0, 0, msg
+                msg = ''
+                for error in errors :
+                    msg += error + ', '
+                return 0, 0, msg[:-1]
             return s_data, f_data, 0 #return value for routes validation
         if s_data and facilitator_file_path is None:
             if len(s_data[0]) != 5:
@@ -108,6 +105,32 @@ def process_csvs(student_file_path, facilitator_file_path):
                 return 0, "Student csv format is incorrect"
             else:
                 return s_data, 0
+
+# checks if headers are correct based on first row only
+def validate_csv_headers(s_data_row, f_data_row) :
+
+    errors = []
+
+    if len(s_data_row) != 5:
+        print("Not a student csv!")
+        errors.append("Student csv format is incorrect")
+    if len(f_data_row) != 1:
+        print("Not a facilitator csv!")
+        errors.append("Facilitator csv format is incorrect")
+
+    student_headers = ["Student ID", "Surname", "Title", "Given Names", "Preferred Name"]
+    factilitator_headers = ["Facilitator Email"]
+
+    for header in student_headers :
+        if header not in s_data_row :
+            errors.append(f"{header} header not detected in student csv")
+
+    for header in factilitator_headers :
+        if header not in f_data_row :
+            errors.append(f"{header} header not detected in facilitator csv")
+
+    return errors
+
 
 # Export a single table's data to a CSV format and return it as a string
 def export_table_to_csv(fetch_function, current_user_id, current_user_type):

--- a/app/utilities.py
+++ b/app/utilities.py
@@ -97,7 +97,7 @@ def process_csvs(student_file_path, facilitator_file_path):
                 msg = ''
                 for error in errors :
                     msg += error + ', '
-                return 0, 0, msg[:-1]
+                return 0, 0, msg[:-2]
             return s_data, f_data, 0 #return value for routes validation
         if s_data and facilitator_file_path is None:
             if len(s_data[0]) != 5:


### PR DESCRIPTION
Changes:
- very basic initial validation is done before adding a unit. now, headers are also validated using the first row. if the headers with exact spelling don't exist (which is required for importing the csvs or it will fail), an error indicating which headers are missing is returned. the unit is not added to the db.
- if a csv passes the initial validation, then the unit is added to the db. the user is now immediately added as a coordinator and facilitator (before student and facilitators are imported) so even if there are errors with the importing, the user will be able to see and edit the unit in unit config page.
- then, students and facilitators are imported into the db. if errors are detected this is flashed to the user, but it is specified that the unit has been uploaded and that they will need to check the student/facilitator list for the unit and edit manually. (FYI because the unit has been added, trying to add another unit with the same start date and unit code will prevent it from submitting - so they should just edit the one already made). note: the only validation for this part i believe that occurs is validation for email to follow a basic format. there is no validation for each student row like student number being 8 digits, or empty values. potentially there may be other errors that actually break the code like before and mean things aren't imported correctly (but looking at the code i can't think of anything)

this is ofc far from perfect, but i'm hoping that most of the time, no errors will even occur, assuming that coordinators can follow the templates and correctly download data from calista db for students
otherwise they can just edit it in unit config (which they will always be able to see all their units in now)